### PR TITLE
fix: DCMAW-14591 changed initialisation of fonts to respect dynamic type correctly

### DIFF
--- a/Sources/DesignSystem/Font.swift
+++ b/Sources/DesignSystem/Font.swift
@@ -6,40 +6,40 @@ extension DesignSystem {
         
         // NOTE: Example mappings from existing
         public enum Base {
-            public static let largeTitle: UIFont = UIFont(style: .largeTitle)
-            public static let largeTitleBold: UIFont = UIFont(style: .largeTitle, weight: .bold)
+            public static let largeTitle: UIFont = UIFont(.largeTitle)
+            public static let largeTitleBold: UIFont = UIFont(.largeTitle, weight: .bold)
             
-            public static let title1: UIFont = UIFont(style: .title1)
-            public static let title1Bold: UIFont = UIFont(style: .title1, weight: .bold)
+            public static let title1: UIFont = UIFont(.title1)
+            public static let title1Bold: UIFont = UIFont(.title1, weight: .bold)
             
-            public static let title2: UIFont = UIFont(style: .title2)
-            public static let title2Bold: UIFont = UIFont(style: .title2, weight: .bold)
+            public static let title2: UIFont = UIFont(.title2)
+            public static let title2Bold: UIFont = UIFont(.title2, weight: .bold)
             
-            public static let title3: UIFont = UIFont(style: .title3)
-            public static let title3Bold: UIFont = UIFont(style: .title3, weight: .bold)
-            public static let title3BoldMonospaced: UIFont = UIFont(style: .title3, weight: .bold, design: .monospaced)
+            public static let title3: UIFont = UIFont(.title3)
+            public static let title3Bold: UIFont = UIFont(.title3, weight: .bold)
+            public static let title3BoldMonospaced: UIFont = UIFont(.title3, weight: .bold, design: .monospaced)
             
-            public static let headline: UIFont = UIFont(style: .headline)
-            public static let headlineBold: UIFont = UIFont(style: .headline, weight: .bold)
+            public static let headline: UIFont = UIFont(.headline)
+            public static let headlineBold: UIFont = UIFont(.headline, weight: .bold)
             
-            public static let subheadline: UIFont = UIFont(style: .subheadline)
-            public static let subheadlineBold: UIFont = UIFont(style: .subheadline, weight: .bold)
+            public static let subheadline: UIFont = UIFont(.subheadline)
+            public static let subheadlineBold: UIFont = UIFont(.subheadline, weight: .bold)
             
-            public static let body: UIFont = UIFont(style: .body)
-            public static let bodySemiBold: UIFont = UIFont(style: .body, weight: .semibold)
-            public static let bodyBold: UIFont = UIFont(style: .body, weight: .bold)
+            public static let body: UIFont = UIFont(.body)
+            public static let bodySemiBold: UIFont = UIFont(.body, weight: .semibold)
+            public static let bodyBold: UIFont = UIFont(.body, weight: .bold)
             
-            public static let callout: UIFont = UIFont(style: .callout)
-            public static let calloutBold: UIFont = UIFont(style: .body, weight: .bold)
+            public static let callout: UIFont = UIFont(.callout)
+            public static let calloutBold: UIFont = UIFont(.body, weight: .bold)
             
-            public static let footnote: UIFont = UIFont(style: .footnote)
-            public static let footnoteBold: UIFont = UIFont(style: .footnote, weight: .bold)
+            public static let footnote: UIFont = UIFont(.footnote)
+            public static let footnoteBold: UIFont = UIFont(.footnote, weight: .bold)
             
-            public static let caption1: UIFont = UIFont(style: .caption1)
-            public static let caption1Bold: UIFont = UIFont(style: .caption1, weight: .bold)
+            public static let caption1: UIFont = UIFont(.caption1)
+            public static let caption1Bold: UIFont = UIFont(.caption1, weight: .bold)
             
-            public static let caption2: UIFont = UIFont(style: .caption2)
-            public static let caption2Bold: UIFont = UIFont(style: .caption2, weight: .bold)
+            public static let caption2: UIFont = UIFont(.caption2)
+            public static let caption2Bold: UIFont = UIFont(.caption2, weight: .bold)
             
         }
     }
@@ -47,7 +47,7 @@ extension DesignSystem {
 
 extension UIFont {
     public convenience init(
-        style: TextStyle,
+        _ style: TextStyle,
         weight: Weight = .regular,
         design: UIFontDescriptor.SystemDesign = .default
     ) {

--- a/Tests/DesignSystemTests/FontTests.swift
+++ b/Tests/DesignSystemTests/FontTests.swift
@@ -7,105 +7,105 @@ struct FontTests {
     // MARK: - Raw Fonts
     
     @Test func test_Font_largeTitle() async throws {
-        let expectedFont = UIFont(style: .largeTitle)
+        let expectedFont = UIFont(.largeTitle)
         
         let sut = DesignSystem.Font.Base.largeTitle
         #expect(sut == expectedFont)
     }
     
     @Test func test_Font_largeTitleBold() async throws {
-        let expectedFont = UIFont(style: .largeTitle, weight: .bold)
+        let expectedFont = UIFont(.largeTitle, weight: .bold)
         
         let sut = DesignSystem.Font.Base.largeTitleBold
         #expect(sut == expectedFont)
     }
     
     @Test func test_Font_title1() async throws {
-        let expectedFont = UIFont(style: .title1)
+        let expectedFont = UIFont(.title1)
         
         let sut = DesignSystem.Font.Base.title1
         #expect(sut == expectedFont)
     }
     
     @Test func test_Font_title2() async throws {
-        let expectedFont = UIFont(style: .title2)
+        let expectedFont = UIFont(.title2)
         
         let sut = DesignSystem.Font.Base.title2
         #expect(sut == expectedFont)
     }
     
     @Test func test_Font_title3() async throws {
-        let expectedFont = UIFont(style: .title3)
+        let expectedFont = UIFont(.title3)
         
         let sut = DesignSystem.Font.Base.title3
         #expect(sut == expectedFont)
     }
     
     @Test func test_Font_title3Bold() async throws {
-        let expectedFont = UIFont(style: .title3, weight: .bold)
+        let expectedFont = UIFont(.title3, weight: .bold)
         
         let sut = DesignSystem.Font.Base.title3Bold
         #expect(sut == expectedFont)
     }
     
     @Test func test_Font_headline() async throws {
-        let expectedFont = UIFont(style: .headline)
+        let expectedFont = UIFont(.headline)
         
         let sut = DesignSystem.Font.Base.headline
         #expect(sut == expectedFont)
     }
     
     @Test func test_Font_subheadline() async throws {
-        let expectedFont = UIFont(style: .subheadline)
+        let expectedFont = UIFont(.subheadline)
         
         let sut = DesignSystem.Font.Base.subheadline
         #expect(sut == expectedFont)
     }
         
     @Test func test_Font_body() async throws {
-        let expectedFont = UIFont(style: .body)
+        let expectedFont = UIFont(.body)
         
         let sut = DesignSystem.Font.Base.body
         #expect(sut == expectedFont)
     }
     
     @Test func test_Font_bodySemiBold() async throws {
-        let expectedFont = UIFont(style: .body, weight: .semibold)
+        let expectedFont = UIFont(.body, weight: .semibold)
         
         let sut = DesignSystem.Font.Base.bodySemiBold
         #expect(sut == expectedFont)
     }
     
     @Test func test_Font_bodyBold() async throws {
-        let expectedFont = UIFont(style: .body, weight: .bold)
+        let expectedFont = UIFont(.body, weight: .bold)
         
         let sut = DesignSystem.Font.Base.bodyBold
         #expect(sut == expectedFont)
     }
     
     @Test func test_Font_callout() async throws {
-        let expectedFont = UIFont(style: .callout)
+        let expectedFont = UIFont(.callout)
         
         let sut = DesignSystem.Font.Base.callout
         #expect(sut == expectedFont)
     }
     
     @Test func test_Font_footnote() async throws {
-        let expectedFont = UIFont(style: .footnote)
+        let expectedFont = UIFont(.footnote)
         
         let sut = DesignSystem.Font.Base.footnote
         #expect(sut == expectedFont)
     }
     
     @Test func test_Font_caption1() async throws {
-        let expectedFont = UIFont(style: .caption1)
+        let expectedFont = UIFont(.caption1)
         
         let sut = DesignSystem.Font.Base.caption1
         #expect(sut == expectedFont)
     }
     
     @Test func test_Font_caption2() async throws {
-        let expectedFont = UIFont(style: .caption2)
+        let expectedFont = UIFont(.caption2)
         
         let sut = DesignSystem.Font.Base.caption2
         #expect(sut == expectedFont)
@@ -113,7 +113,7 @@ struct FontTests {
 
     // MARK: - Font Helpers
     @Test func test_Font_preferredMonospacedFont() async throws {
-        let expectedFont = UIFont(style: .title3, weight: .bold, design: .monospaced)
+        let expectedFont = UIFont(.title3, weight: .bold, design: .monospaced)
         
         let sut = DesignSystem.Font.Base.title3BoldMonospaced
         #expect(sut == expectedFont)


### PR DESCRIPTION
# Fixing dynamic type fonts

Before this PR, fonts would change size with dynamic type, but if set to a large size when loading, the large size would be doubled. I couldn't see an obvious way to resolve it with the previous initialisation approach so this brings over the `convenience init` from `GDSCommon`.

https://govukverify.atlassian.net/browse/DCMAW-14591

# Checklist

## Before raising your pull request:
- [x] Ran and tested the app locally ensuring it builds
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
