### PR TITLE
fix: setting accessibility hint from icon

### DIFF
--- a/Sources/DesignSystem/Components/GDSButton/UIButtonUpdater+Extension.swift
+++ b/Sources/DesignSystem/Components/GDSButton/UIButtonUpdater+Extension.swift
@@ -68,6 +68,11 @@ extension UIButton {
                 button.configuration?.contentInsets.leading = DesignSystem.Spacing.xSmall
             }
             
+            if let icon = viewModel.icon?.forState(button.state),
+               let accessibilityHint = icon.accessibilityHint {
+                button.accessibilityHint = accessibilityHint
+            }
+            
             switch button.state {
             case .normal:
                 if viewModel.style.backgroundColor.forState(button.state) == UIColor.systemBackground


### PR DESCRIPTION
# Missed implementation

Missed setting the accessibility hint from the icon.

# Checklist

## Before raising your pull request:
- [ ] Ran and tested the app locally ensuring it builds
- [ ] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
