### PR TITLE
feat: added voiceover focus

### DIFF
--- a/Sources/DesignSystem/Components/GDSButton/GDSButton.swift
+++ b/Sources/DesignSystem/Components/GDSButton/GDSButton.swift
@@ -105,4 +105,17 @@ public final class GDSButton: UIButton {
             return false
         }
     }
+    
+    public override func accessibilityElementDidLoseFocus() {
+        super.accessibilityElementDidLoseFocus()
+        self.setNeedsUpdateConfiguration()
+    }
+    
+    public override func accessibilityElementDidBecomeFocused() {
+        super.accessibilityElementDidBecomeFocused()
+        var config = self.configuration
+        config?.baseBackgroundColor = viewModel.style.backgroundColor.forState(.focused)
+        config?.baseForegroundColor = viewModel.style.foregroundColor.forState(.focused)
+        self.configuration = config
+    }
 }


### PR DESCRIPTION
# Added responding to VoiceOver focus

VoiceOver doesn't interact with buttons in the same way that Full Keyboard Access does. Focusing on a button with VoiceOver does not initiate a state change on the button and therefore changing the button style needs to be achieved in a different way.

This implements overriding methods on the button that then use the button style to set the button to have the `focused` style when selected and reverts to standard state change behaviour after focus is removed. 

After the change:
https://github.com/user-attachments/assets/447a7a6a-931b-4434-9dca-80662a6d71f1


Before the change:
https://github.com/user-attachments/assets/c899210d-7aab-4afd-b3a0-9c89b9947e2e


# Checklist

## Before raising your pull request:
- [x] Ran and tested the app locally ensuring it builds
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
