### PR TITLE
fix: DCMAW-19101 & DCMAW-19099 User interactions on non-interactive list items

### DIFF
--- a/Sources/DesignSystem/Components/GDSList.swift
+++ b/Sources/DesignSystem/Components/GDSList.swift
@@ -99,7 +99,9 @@ public final class GDSList: UIView, ContentView {
         reloadListView()
     }
     
-    private func contentLabels(for item: GDSLocalisedString) -> UILabel {
+    private func contentLabels(
+        for item: GDSLocalisedString
+    ) -> UILabel {
         let label = UILabel(colour: DesignSystem.Color.GDSList.label)
         label.font = DesignSystem.Font.Base.body
         
@@ -108,6 +110,7 @@ public final class GDSList: UIView, ContentView {
         } else {
             label.text = item.value
         }
+        
         return label
     }
     
@@ -157,6 +160,8 @@ public final class GDSList: UIView, ContentView {
                 ? "numbered-list-row-stack-view-\(rowNumber)"
                 : "bulleted-list-row-stack-view-\(rowNumber)"
                 
+                row.accessibilityRespondsToUserInteraction = false
+                
                 return row
             }
     }
@@ -178,6 +183,7 @@ public final class GDSList: UIView, ContentView {
         marker.textAlignment = .right
         marker.font = DesignSystem.Font.Base.body
         marker.widthAnchor.constraint(equalToConstant: maxNumberWidth).isActive = true
+        
         return marker
     }
     
@@ -203,7 +209,6 @@ public final class GDSList: UIView, ContentView {
         row.isLayoutMarginsRelativeArrangement = true
         row.layoutMargins.left = DesignSystem.Spacing.GDSList.leadingMargin
         row.isAccessibilityElement = true
-        row.accessibilityRespondsToUserInteraction = false
         
         return row
     }

--- a/Sources/DesignSystem/Components/GDSList.swift
+++ b/Sources/DesignSystem/Components/GDSList.swift
@@ -202,8 +202,9 @@ public final class GDSList: UIView, ContentView {
         
         row.isLayoutMarginsRelativeArrangement = true
         row.layoutMargins.left = DesignSystem.Spacing.GDSList.leadingMargin
-        
         row.isAccessibilityElement = true
+        row.accessibilityRespondsToUserInteraction = false
+        
         return row
     }
 }

--- a/Tests/DesignSystemTests/Views/GDSList/GDSListTests.swift
+++ b/Tests/DesignSystemTests/Views/GDSList/GDSListTests.swift
@@ -57,6 +57,7 @@ struct GDSListTests {
         let firstRow: UIStackView? = sut[child: "numbered-list-row-stack-view-1"]
         
         #expect(firstRow?.accessibilityLabel == "numbered list 2 items, 1, first numbered list item")
+        #expect(firstRow?.accessibilityRespondsToUserInteraction == false)
     }
     
     @Test("Accessibility label for second row in numbered List")
@@ -65,6 +66,7 @@ struct GDSListTests {
         let secondRow: UIStackView? = sut[child: "numbered-list-row-stack-view-2"]
         
         #expect(secondRow?.accessibilityLabel == "2, second numbered list item")
+        #expect(secondRow?.accessibilityRespondsToUserInteraction == false)
     }
     
     @Test("Number label and content label are set correctly")
@@ -122,6 +124,7 @@ struct GDSListTests {
         let firstRow: UIStackView? = sut[child: "bulleted-list-row-stack-view-1"]
         
         #expect(firstRow?.accessibilityLabel == "bulleted list 2 items, bullet, first bulleted list item")
+        #expect(firstRow?.accessibilityRespondsToUserInteraction == false)
     }
     
     @Test("Accessibility label for second row in bulleted List")
@@ -130,6 +133,7 @@ struct GDSListTests {
         let secondRow: UIStackView? = sut[child: "bulleted-list-row-stack-view-2"]
         
         #expect(secondRow?.accessibilityLabel == "bullet, second bulleted list item")
+        #expect(secondRow?.accessibilityRespondsToUserInteraction == false)
     }
     
     @Test("Bullet point and content label are set correctly")


### PR DESCRIPTION
# [DCMAW-19101](https://govukverify.atlassian.net/browse/DCMAW-19101) & [DCMAW-19099 ](https://govukverify.atlassian.net/browse/DCMAW-19099)
Disables users interactions from list rows 

Voice control - list items should not be numbered 
Keyboard - users should not be able to tab through list items via keyboard
VoiceOver - list items should have focus state and custom announcements maintained

### Voice Control enabled (Show numbers)
#### Before
![IMG_0106 2](https://github.com/user-attachments/assets/a0177228-2048-47f6-a28d-6b14515ef2e2)

#### After
![IMG_0105 2](https://github.com/user-attachments/assets/051d0d6e-ebc7-446b-9004-1527976cf7a3)


### VoiceOver behaviour
https://github.com/user-attachments/assets/14564ba8-83e8-4dab-a265-cfcc5a4b71da


### Keyboard focus 
#### Before
https://github.com/user-attachments/assets/b0fd82dd-035f-49f5-924b-5337850c3975

#### After
https://github.com/user-attachments/assets/53e573ef-432b-4ca6-87c5-72882201b0c0

# Checklist

## Before raising your pull request:
- [ ] Ran and tested the app locally ensuring it builds
- [ ] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`


[DCMAW-19101]: https://govukverify.atlassian.net/browse/DCMAW-19101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ