### PR TITLE
fix: DCMAW-17896 & DCMAW-19099 remove duplicate accessibility hint and ensure all accessible in scrollviews

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,6 +9,7 @@ disabled_rules:
 - cyclomatic_complexity
 - multiple_closures_with_trailing_closure
 - todo
+- trailing_comma
 
 analyzer_rules:
 - unused_import

--- a/Demo/DesignSystemDemo/SceneDelegate.swift
+++ b/Demo/DesignSystemDemo/SceneDelegate.swift
@@ -13,7 +13,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = ViewController()
+        window.rootViewController = UINavigationController(rootViewController: ViewController())
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/Demo/DesignSystemDemo/ViewController.swift
+++ b/Demo/DesignSystemDemo/ViewController.swift
@@ -82,7 +82,6 @@ class ViewController: UIViewController {
 // MARK: - View Models
 
 extension ViewController {
-    // swiftlint:disable function_body_length
     var bodyContent: [any ContentViewModel] {
         [
             GDSButtonViewModel(
@@ -277,7 +276,6 @@ extension ViewController {
             }
         ]
     }
-    // swiftlint:enable function_body_length
 
     var gdsScreenViewModel: GDSDemoScreenViewModel {
         GDSDemoScreenViewModel(

--- a/Demo/DesignSystemDemo/ViewController.swift
+++ b/Demo/DesignSystemDemo/ViewController.swift
@@ -11,204 +11,17 @@ public struct TestViewControllerViewModel: ScreenViewModel {
 class ViewController: UIViewController {
     var viewModel: TestViewControllerViewModel {
         TestViewControllerViewModel(
-            body: [
-                GDSButtonViewModel(
-                    title: "Push GDSScreen",
-                    style: .secondary,
-                    buttonAction: .action({ [weak self] in
-                        self?.pushGDSScreen()
-                    })
-                ),
-                GDSTextViewModel(
-                    title: "Simple test label",
-                    titleFont: DesignSystem.Font.Base.body,
-                    alignment: .left
-                ),
-                GDSErrorIconTitleViewModel(
-                    icon: .error,
-                    errorTitle: GDSTextViewModel(
-                    title: "There is a problem",
-                    titleFont: DesignSystem.Font.Base.title1Bold,
-                    alignment: .center,
-                    accessibilityTraits: .header,
-                    verticalPadding: .bottom(8)
-                    )
-                ),
-                GDSErrorIconTitleViewModel(
-                    icon: .warning,
-                    errorTitle: GDSTextViewModel(
-                    title: "There is a problem",
-                    titleFont: DesignSystem.Font.Base.title1Bold,
-                    alignment: .center,
-                    accessibilityTraits: UIAccessibilityTraits.none,
-                    verticalPadding: .bottom(8)
-                    )
-                ),
-                GDSMultiRowViewModel(rows: [
-                    GDSRowViewModel(
-                        titleConfig: StyledText(text: "Test Title Label 1"),
-                        detailConfig: StyledText(text: "20"),
-                        iconStyle: IconStyle(icon: "chevron.right"),
-                        type: .regular
-                    ),
-                    GDSRowViewModel(
-                        titleConfig: StyledText(text: "Test Title Label 2", colour: .red),
-                        subtitleConfig: StyledText(text: "Test Subtitle"),
-                        detailConfig: StyledText(text: "14"),
-                        image: UIImage(named: "exampleImage"),
-                        iconStyle: IconStyle(icon: "arrow.up.right", colour: .blue, accessibilityHint: "this is icon alt text")
-                    ),
-                    GDSRowViewModel(
-                        titleConfig: StyledText(text: "Test Title Label 3"),
-                        image: UIImage(named: "vetCard"),
-                        iconStyle: .arrowUpRight,
-                        action: .action(
-                            {
-                                UIApplication.shared.open(URL(string: "https://www.google.com")!)
-                            }
-                        )
-                    ),
-                    GDSRowViewModel(
-                        titleConfig: StyledText(text: "Test Title Label 4")
-                    )
-                ]),
-                GDSListViewModel(
-                    title: "Numbered List",
-                    titleConfig: (font: DesignSystem.Font.Base.title3Bold, isHeader: true),
-                    items: [
-                        "take a photo",
-                        GDSLocalisedString(
-                            stringKey: "This is bold, this is not",
-                            stringAttributes: [("This is bold",
-                                                [.font: UIFont(.body, weight: .bold)])]
-                        ),
-                        "Item 2",
-                        "Item 3"
-                    ],
-                    style: .numbered
-                ),
-                GDSListViewModel(
-                    title: "Bulleted List",
-                    titleConfig: (font: DesignSystem.Font.Base.body, isHeader: false),
-                    items: [
-                        "take a photo",
-                        GDSLocalisedString(
-                            stringLiteral: "second numbered list item",
-                            stringAttributes: [("numbered list", [.font: DesignSystem.Font.Base.bodyBold])]
-                        ),
-                        "Item 3"
-                    ],
-                    style: .bulleted
-                ),
-                GDSListViewModel(
-                    items: [
-                        GDSLocalisedString(
-                            stringLiteral: "Item 1 - this is an example of a numbered list without a title, long texts should wrap!",
-                            stringAttributes: [("wrap!", [.font: DesignSystem.Font.Base.bodyBold])]
-                        ),
-                        "Item 2",
-                        "Item 3"
-                    ],
-                    style: .numbered
-                ),
-                GDSListViewModel(
-                    items: [
-                        "Item 1",
-                        GDSLocalisedString(
-                            stringKey: "second bulleted list item",
-                            stringAttributes: [("numbered list", [.font: DesignSystem.Font.Base.bodyBold])]
-                        ),
-                        "Item 3"
-                    ],
-                    style: .bulleted
-                ),
-                GDSCardViewModel(
-                    showShadow: true,
-                    dismissAction: .action({ })
-                ) {
-                    GDSImageViewModel(
-                        image: UIImage(named: "placeholder") ?? UIImage(),
-                        contentMode: .scaleAspectFit
-                    )
-                    GDSTextViewModel(
-                        title: GDSLocalisedString(
-                            stringLiteral: "Here is the caption for the picture",
-                            stringAttributes: [("Here is the caption for the picture",
-                                                [.foregroundColor: DesignSystem.Color.Icons.success])]
-                        ),
-                        verticalPadding: .vertical(8)
-                    )
-                    GDSTextViewModel(
-                        title: "A title for the component for a quick introduction",
-                        titleFont: DesignSystem.Font.Base.title1Bold,
-                        verticalPadding: .bottom(8)
-                    )
-                    GDSTextViewModel(
-                        title: "A subtitle for the componenet which can be used to describe it's purpose",
-                        verticalPadding: .bottom(8)
-                    )
-                    GDSDividerViewModel(
-                        verticalPadding: .bottom(8)
-                    )
-                    GDSButtonViewModel(
-                        title: "Secondary Button",
-                        style: .secondary,
-                        buttonAction: .action({ }),
-                        verticalPadding: .bottom(8),
-                        horizontalPadding: .horizontal(16)
-                    )
-                    GDSButtonViewModel(
-                        title: "Primary Button",
-                        style: .primary,
-                        buttonAction: .action({ }),
-                        verticalPadding: .bottom(16),
-                        horizontalPadding: .horizontal(16)
-                    )
-                },
-                GDSCardViewModel(
-                    showShadow: true,
-                    dismissAction: .action({ })
-                ) {
-                    GDSCardTitleViewModel(
-                        title: "A title for the component",
-                        verticalPadding: .bottom(8),
-                        horizontalPadding: .leading(16)
-                    )
-                    GDSTextViewModel(
-                        title: "A subtitle for the componenet which can be used to describe it's purpose",
-                        verticalPadding: .bottom(8)
-                    )
-                    GDSDividerViewModel(
-                        verticalPadding: .bottom(8)
-                    )
-                    GDSButtonViewModel(
-                        title: "Secondary Button",
-                        icon: .arrowUpRight,
-                        style: .secondary.adjusting(
-                            alignment: .leading,
-                            contentInsets: NSDirectionalEdgeInsets(
-                                top: DesignSystem.Spacing.small,
-                                leading: .zero,
-                                bottom: DesignSystem.Spacing.small,
-                                trailing: DesignSystem.Spacing.default
-                            )
-                        ),
-                        buttonAction: .action({ }),
-                        verticalPadding: .bottom(8),
-                        horizontalPadding: .horizontal(16)
-                    )
-                }
-            ],
+            body: bodyContent,
             moveableFooter: [],
             footer: []
         )
     }
-    
+
     lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         return scrollView
     }()
-    
+
     lazy var stackview: UIStackView = {
         let stackview = UIStackView()
         stackview.axis = .vertical
@@ -224,20 +37,250 @@ class ViewController: UIViewController {
         )
         return stackview
     }()
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
         title = "Design System Demo"
-        
+
         scrollView.addSubview(stackview)
         view.addSubview(scrollView)
         configureConstraints()
         addViewsToStack()
     }
-    
+
     func pushGDSScreen() {
-        let viewModel = GDSDemoScreenViewModel(
+        let screen = GDSScreen(viewModel: gdsScreenViewModel)
+        navigationController?.pushViewController(screen, animated: true)
+    }
+
+    func addViewsToStack() {
+        viewModel.body.forEach {
+            stackview.addArrangedSubview($0.createUIView())
+        }
+    }
+
+    func configureConstraints() {
+        stackview.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate(
+            [
+                scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+                scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+                scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+                scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+
+                stackview.leadingAnchor.constraint(equalTo: scrollView.frameLayoutGuide.leadingAnchor),
+                stackview.trailingAnchor.constraint(equalTo: scrollView.frameLayoutGuide.trailingAnchor),
+                stackview.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+                stackview.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor)
+            ]
+        )
+    }
+}
+
+// MARK: - View Models
+
+extension ViewController {
+    // swiftlint:disable function_body_length
+    var bodyContent: [any ContentViewModel] {
+        [
+            GDSButtonViewModel(
+                title: "Push GDSScreen",
+                style: .secondary,
+                buttonAction: .action({ [weak self] in
+                    self?.pushGDSScreen()
+                })
+            ),
+            GDSTextViewModel(
+                title: "Simple test label",
+                titleFont: DesignSystem.Font.Base.body,
+                alignment: .left
+            ),
+            GDSErrorIconTitleViewModel(
+                icon: .error,
+                errorTitle: GDSTextViewModel(
+                    title: "There is a problem",
+                    titleFont: DesignSystem.Font.Base.title1Bold,
+                    alignment: .center,
+                    accessibilityTraits: .header,
+                    verticalPadding: .bottom(8)
+                )
+            ),
+            GDSErrorIconTitleViewModel(
+                icon: .warning,
+                errorTitle: GDSTextViewModel(
+                    title: "There is a problem",
+                    titleFont: DesignSystem.Font.Base.title1Bold,
+                    alignment: .center,
+                    accessibilityTraits: UIAccessibilityTraits.none,
+                    verticalPadding: .bottom(8)
+                )
+            ),
+            GDSMultiRowViewModel(rows: [
+                GDSRowViewModel(
+                    titleConfig: StyledText(text: "Test Title Label 1"),
+                    detailConfig: StyledText(text: "20"),
+                    iconStyle: IconStyle(icon: "chevron.right"),
+                    type: .regular
+                ),
+                GDSRowViewModel(
+                    titleConfig: StyledText(text: "Test Title Label 2", colour: .red),
+                    subtitleConfig: StyledText(text: "Test Subtitle"),
+                    detailConfig: StyledText(text: "14"),
+                    image: UIImage(named: "exampleImage"),
+                    iconStyle: IconStyle(
+                        icon: "arrow.up.right",
+                        colour: .blue,
+                        accessibilityHint: "this is icon alt text"
+                    )
+                ),
+                GDSRowViewModel(
+                    titleConfig: StyledText(text: "Test Title Label 3"),
+                    image: UIImage(named: "vetCard"),
+                    iconStyle: .arrowUpRight,
+                    action: .action(
+                        {
+                            UIApplication.shared.open(URL(string: "https://www.google.com")!)
+                        }
+                    )
+                ),
+                GDSRowViewModel(
+                    titleConfig: StyledText(text: "Test Title Label 4")
+                )
+            ]),
+            GDSListViewModel(
+                title: "Numbered List",
+                titleConfig: (font: DesignSystem.Font.Base.title3Bold, isHeader: true),
+                items: [
+                    "take a photo",
+                    GDSLocalisedString(
+                        stringKey: "This is bold, this is not",
+                        stringAttributes: [("This is bold",
+                                            [.font: UIFont(.body, weight: .bold)])]
+                    ),
+                    "Item 2",
+                    "Item 3"
+                ],
+                style: .numbered
+            ),
+            GDSListViewModel(
+                title: "Bulleted List",
+                titleConfig: (font: DesignSystem.Font.Base.body, isHeader: false),
+                items: [
+                    "take a photo",
+                    GDSLocalisedString(
+                        stringLiteral: "second numbered list item",
+                        stringAttributes: [("numbered list", [.font: DesignSystem.Font.Base.bodyBold])]
+                    ),
+                    "Item 3"
+                ],
+                style: .bulleted
+            ),
+            GDSListViewModel(
+                items: [
+                    GDSLocalisedString(
+                        stringLiteral: "Item 1 - this is an example of a numbered list without a title, long texts should wrap!",
+                        stringAttributes: [("wrap!", [.font: DesignSystem.Font.Base.bodyBold])]
+                    ),
+                    "Item 2",
+                    "Item 3"
+                ],
+                style: .numbered
+            ),
+            GDSListViewModel(
+                items: [
+                    "Item 1",
+                    GDSLocalisedString(
+                        stringKey: "second bulleted list item",
+                        stringAttributes: [("numbered list", [.font: DesignSystem.Font.Base.bodyBold])]
+                    ),
+                    "Item 3"
+                ],
+                style: .bulleted
+            ),
+            GDSCardViewModel(
+                showShadow: true,
+                dismissAction: .action({ })
+            ) {
+                GDSImageViewModel(
+                    image: UIImage(named: "placeholder") ?? UIImage(),
+                    contentMode: .scaleAspectFit
+                )
+                GDSTextViewModel(
+                    title: GDSLocalisedString(
+                        stringLiteral: "Here is the caption for the picture",
+                        stringAttributes: [("Here is the caption for the picture",
+                                            [.foregroundColor: DesignSystem.Color.Icons.success])]
+                    ),
+                    verticalPadding: .vertical(8)
+                )
+                GDSTextViewModel(
+                    title: "A title for the component for a quick introduction",
+                    titleFont: DesignSystem.Font.Base.title1Bold,
+                    verticalPadding: .bottom(8)
+                )
+                GDSTextViewModel(
+                    title: "A subtitle for the componenet which can be used to describe it's purpose",
+                    verticalPadding: .bottom(8)
+                )
+                GDSDividerViewModel(
+                    verticalPadding: .bottom(8)
+                )
+                GDSButtonViewModel(
+                    title: "Secondary Button",
+                    style: .secondary,
+                    buttonAction: .action({ }),
+                    verticalPadding: .bottom(8),
+                    horizontalPadding: .horizontal(16)
+                )
+                GDSButtonViewModel(
+                    title: "Primary Button",
+                    style: .primary,
+                    buttonAction: .action({ }),
+                    verticalPadding: .bottom(16),
+                    horizontalPadding: .horizontal(16)
+                )
+            },
+            GDSCardViewModel(
+                showShadow: true,
+                dismissAction: .action({ })
+            ) {
+                GDSCardTitleViewModel(
+                    title: "A title for the component",
+                    verticalPadding: .bottom(8),
+                    horizontalPadding: .leading(16)
+                )
+                GDSTextViewModel(
+                    title: "A subtitle for the componenet which can be used to describe it's purpose",
+                    verticalPadding: .bottom(8)
+                )
+                GDSDividerViewModel(
+                    verticalPadding: .bottom(8)
+                )
+                GDSButtonViewModel(
+                    title: "Secondary Button",
+                    icon: .arrowUpRight,
+                    style: .secondary.adjusting(
+                        alignment: .leading,
+                        contentInsets: NSDirectionalEdgeInsets(
+                            top: DesignSystem.Spacing.small,
+                            leading: .zero,
+                            bottom: DesignSystem.Spacing.small,
+                            trailing: DesignSystem.Spacing.default
+                        )
+                    ),
+                    buttonAction: .action({ }),
+                    verticalPadding: .bottom(8),
+                    horizontalPadding: .horizontal(16)
+                )
+            }
+        ]
+    }
+    // swiftlint:enable function_body_length
+
+    var gdsScreenViewModel: GDSDemoScreenViewModel {
+        GDSDemoScreenViewModel(
             body: [
                 GDSTextViewModel(
                     title: "Simple test label",
@@ -264,7 +307,7 @@ class ViewController: UIViewController {
                         horizontalPadding: .leading(16)
                     )
                     GDSTextViewModel(
-                        title: "A subtitle for the componenet which can be used to describe it's purpose",
+                        title: "A subtitle for the component",
                         verticalPadding: .bottom(8)
                     )
                     GDSDividerViewModel(
@@ -286,32 +329,6 @@ class ViewController: UIViewController {
                     style: .primary,
                     buttonAction: .action({ })
                 )
-            ]
-        )
-        let screen = GDSScreen(viewModel: viewModel)
-        navigationController?.pushViewController(screen, animated: true)
-    }
-    
-    func addViewsToStack() {
-        viewModel.body.forEach {
-            stackview.addArrangedSubview($0.createUIView())
-        }
-    }
-    
-    func configureConstraints() {
-        stackview.translatesAutoresizingMaskIntoConstraints = false
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate(
-            [
-                scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-                scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-                scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-                scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-                
-                stackview.leadingAnchor.constraint(equalTo: scrollView.frameLayoutGuide.leadingAnchor),
-                stackview.trailingAnchor.constraint(equalTo: scrollView.frameLayoutGuide.trailingAnchor),
-                stackview.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
-                stackview.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor)
             ]
         )
     }

--- a/Demo/DesignSystemDemo/ViewController.swift
+++ b/Demo/DesignSystemDemo/ViewController.swift
@@ -12,6 +12,18 @@ class ViewController: UIViewController {
     var viewModel: TestViewControllerViewModel {
         TestViewControllerViewModel(
             body: [
+                GDSButtonViewModel(
+                    title: "Push GDSScreen",
+                    style: .secondary,
+                    buttonAction: .action({ [weak self] in
+                        self?.pushGDSScreen()
+                    })
+                ),
+                GDSTextViewModel(
+                    title: "Simple test label",
+                    titleFont: DesignSystem.Font.Base.body,
+                    alignment: .left
+                ),
                 GDSErrorIconTitleViewModel(
                     icon: .error,
                     errorTitle: GDSTextViewModel(
@@ -216,11 +228,68 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
+        title = "Design System Demo"
         
         scrollView.addSubview(stackview)
         view.addSubview(scrollView)
         configureConstraints()
         addViewsToStack()
+    }
+    
+    func pushGDSScreen() {
+        let viewModel = GDSDemoScreenViewModel(
+            body: [
+                GDSTextViewModel(
+                    title: "Simple test label",
+                    titleFont: DesignSystem.Font.Base.body,
+                    alignment: .left
+                ),
+                GDSListViewModel(
+                    title: "Numbered List",
+                    titleConfig: (font: DesignSystem.Font.Base.title3Bold, isHeader: true),
+                    items: [
+                        "Item 1",
+                        "Item 2",
+                        "Item 3"
+                    ],
+                    style: .numbered
+                ),
+                GDSCardViewModel(
+                    showShadow: true,
+                    dismissAction: .action({ })
+                ) {
+                    GDSCardTitleViewModel(
+                        title: "A title for the component",
+                        verticalPadding: .bottom(8),
+                        horizontalPadding: .leading(16)
+                    )
+                    GDSTextViewModel(
+                        title: "A subtitle for the componenet which can be used to describe it's purpose",
+                        verticalPadding: .bottom(8)
+                    )
+                    GDSDividerViewModel(
+                        verticalPadding: .bottom(8)
+                    )
+                    GDSButtonViewModel(
+                        title: "Primary Button",
+                        style: .primary,
+                        buttonAction: .action({ }),
+                        verticalPadding: .bottom(16),
+                        horizontalPadding: .horizontal(16)
+                    )
+                }
+            ],
+            movableFooter: [],
+            footer: [
+                GDSButtonViewModel(
+                    title: "Footer Button",
+                    style: .primary,
+                    buttonAction: .action({ })
+                )
+            ]
+        )
+        let screen = GDSScreen(viewModel: viewModel)
+        navigationController?.pushViewController(screen, animated: true)
     }
     
     func addViewsToStack() {

--- a/Sources/DesignSystem/Components/GDSListViewModel.swift
+++ b/Sources/DesignSystem/Components/GDSListViewModel.swift
@@ -33,8 +33,4 @@ public struct GDSListViewModel: ContentViewModel {
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontal
     }
-    
-    public func createUIView() -> UIView {
-        GDSList(viewModel: self)
-    }
 }

--- a/Sources/DesignSystem/Screens/GDSScreen.swift
+++ b/Sources/DesignSystem/Screens/GDSScreen.swift
@@ -120,25 +120,13 @@ open class GDSScreen: BaseScreen, VoiceOverFocus {
         addRelativeViewConstraints()
     }
     
-    /// Ensures Full Keyboard Access can focus inside the scroll view
-    /// by marking the first accessibility element as responding to
-    /// user interaction, providing an entry point for keyboard scrolling.
+    /// Ensures Full Keyboard Access can scroll the view by marking
+    /// each subview as an accessibility element, working around an
+    /// iOS defect where FKA cannot reach content inside scroll views.
     func configureScrollViewAccessibility() {
-        if let element = findFirstAccessibilityElement(in: scrollViewInnerStackView) {
-            element.accessibilityRespondsToUserInteraction = true
+        for subview in scrollViewInnerStackView.arrangedSubviews {
+            subview.isAccessibilityElement = true
         }
-    }
-    
-    private func findFirstAccessibilityElement(in view: UIView) -> UIView? {
-        if view.isAccessibilityElement {
-            return view
-        }
-        for subview in view.subviews {
-            if let found = findFirstAccessibilityElement(in: subview) {
-                return found
-            }
-        }
-        return nil
     }
     
     private func addRelativeViewConstraints() {

--- a/Sources/DesignSystem/Screens/GDSScreen.swift
+++ b/Sources/DesignSystem/Screens/GDSScreen.swift
@@ -121,11 +121,21 @@ open class GDSScreen: BaseScreen, VoiceOverFocus {
     }
     
     /// Ensures Full Keyboard Access can scroll the view by marking
-    /// each subview as an accessibility element, working around an
-    /// iOS defect where FKA cannot reach content inside scroll views.
+    /// all leaf views inside the scroll view as responding to user
+    /// interaction, working around an iOS limitation where FKA
+    /// cannot focus inside scroll views with no interactive elements.
     func configureScrollViewAccessibility() {
-        for subview in scrollViewInnerStackView.arrangedSubviews {
-            subview.isAccessibilityElement = true
+        setAccessibilityRespondsToUserInteraction(in: scrollViewInnerStackView)
+    }
+    
+    private func setAccessibilityRespondsToUserInteraction(in view: UIView) {
+        if view.subviews.isEmpty || view.isAccessibilityElement {
+            view.isAccessibilityElement = true
+            view.accessibilityRespondsToUserInteraction = true
+            return
+        }
+        for subview in view.subviews {
+            setAccessibilityRespondsToUserInteraction(in: subview)
         }
     }
     

--- a/Sources/DesignSystem/Screens/GDSScreen.swift
+++ b/Sources/DesignSystem/Screens/GDSScreen.swift
@@ -102,7 +102,6 @@ open class GDSScreen: BaseScreen, VoiceOverFocus {
     open override func viewDidLoad() {
         super.viewDidLoad()
         setup()
-        configureScrollViewAccessibility()
     }
     
     open override func viewDidLayoutSubviews() {
@@ -118,25 +117,6 @@ open class GDSScreen: BaseScreen, VoiceOverFocus {
         containerStackView.bindToSuperviewSafeArea()
         view.backgroundColor = .systemBackground
         addRelativeViewConstraints()
-    }
-    
-    /// Ensures Full Keyboard Access can scroll the view by marking
-    /// all leaf views inside the scroll view as responding to user
-    /// interaction, working around an iOS limitation where FKA
-    /// cannot focus inside scroll views with no interactive elements.
-    func configureScrollViewAccessibility() {
-        setAccessibilityRespondsToUserInteraction(in: scrollViewInnerStackView)
-    }
-    
-    private func setAccessibilityRespondsToUserInteraction(in view: UIView) {
-        if view.subviews.isEmpty || view.isAccessibilityElement {
-            view.isAccessibilityElement = true
-            view.accessibilityRespondsToUserInteraction = true
-            return
-        }
-        for subview in view.subviews {
-            setAccessibilityRespondsToUserInteraction(in: subview)
-        }
     }
     
     private func addRelativeViewConstraints() {

--- a/Sources/DesignSystem/Views/ContentView.swift
+++ b/Sources/DesignSystem/Views/ContentView.swift
@@ -10,7 +10,19 @@ public protocol ContentViewModel {
 
 extension ContentViewModel {
     public func createUIView() -> UIView {
-        ViewType(viewModel: self)
+        let view = ViewType(viewModel: self)
+        Self.enableAccessibilityInteraction(in: view)
+        return view
+    }
+    
+    private static func enableAccessibilityInteraction(in view: UIView) {
+        if view.isAccessibilityElement {
+            view.accessibilityRespondsToUserInteraction = true
+            return
+        }
+        for subview in view.subviews {
+            enableAccessibilityInteraction(in: subview)
+        }
     }
 }
 

--- a/Sources/DesignSystem/Views/GDSRow/GDSRow.swift
+++ b/Sources/DesignSystem/Views/GDSRow/GDSRow.swift
@@ -260,7 +260,6 @@ public final class GDSRow: UIControl, ContentView {
             titleLabel.text,
             viewModel.subtitle,
             viewModel.detail,
-            viewModel.iconStyle?.accessibilityHint
         ]
             .compactMap { $0 }
         

--- a/Tests/DesignSystemTests/Screens/GDSScreenTests.swift
+++ b/Tests/DesignSystemTests/Screens/GDSScreenTests.swift
@@ -132,15 +132,10 @@ struct GDSScreenTests {
         )
         let sut = GDSScreen(viewModel: viewModel)
         
-        let bodyItemStack = sut.scrollViewInnerStackView.arrangedSubviews.first as? UIStackView
-        let textView = bodyItemStack?.arrangedSubviews.first as? GDSTextView
-        // UILabel.isAccessibilityElement is true at runtime but not in unit tests,
-        // so set it explicitly to simulate runtime behaviour
-        textView?.isAccessibilityElement = true
-        
         sut.configureScrollViewAccessibility()
         
-        #expect(textView?.accessibilityRespondsToUserInteraction == true)
+        let bodyItemStack = sut.scrollViewInnerStackView.arrangedSubviews.first as? UIStackView
+        #expect(bodyItemStack?.isAccessibilityElement == true)
     }
     
     @Test("First accessibility element in GDSList body responds to user interaction for Full Keyboard Access")
@@ -157,17 +152,10 @@ struct GDSScreenTests {
         )
         let sut = GDSScreen(viewModel: viewModel)
         
-        let bodyItemStack = sut.scrollViewInnerStackView.arrangedSubviews.first as? UIStackView
-        let list = bodyItemStack?.arrangedSubviews.first as? GDSList
-        // GDSList rows have isAccessibilityElement = true set in createRow()
-        // Find the first row stack view
-        let listStack = list?.subviews.first as? UIStackView
-        // First arranged subview after the title is the first row
-        let firstRow = listStack?.arrangedSubviews.first(where: { $0.isAccessibilityElement })
-        
         sut.configureScrollViewAccessibility()
         
-        #expect(firstRow?.accessibilityRespondsToUserInteraction == true)
+        let bodyItemStack = sut.scrollViewInnerStackView.arrangedSubviews.first as? UIStackView
+        #expect(bodyItemStack?.isAccessibilityElement == true)
     }
     
     @Test("Empty body does not crash when configuring scroll view accessibility")

--- a/Tests/DesignSystemTests/Screens/GDSScreenTests.swift
+++ b/Tests/DesignSystemTests/Screens/GDSScreenTests.swift
@@ -122,51 +122,26 @@ struct GDSScreenTests {
         #expect(sut.bottomStackView.arrangedSubviews.count == 2)
     }
     
-    @Test("First accessibility element in scroll view responds to user interaction for Full Keyboard Access")
-    func scrollViewAccessibility_textBody() {
-        let viewModel = TestGDSScreenViewModel(
-            screenStyle: .top,
-            body: [GDSTextViewModel(title: "test body text")],
-            movableFooter: [],
-            footer: []
+    @Test("ContentView with isAccessibilityElement true gets accessibilityRespondsToUserInteraction set")
+    func contentView_accessibilityElementRespondsToUserInteraction() {
+        // GDSList rows explicitly set isAccessibilityElement = true in createRow(),
+        // so they get accessibilityRespondsToUserInteraction set at creation time
+        let viewModel = GDSListViewModel(
+            title: GDSLocalisedString(stringKey: "test"),
+            items: [GDSLocalisedString(stringKey: "item1")],
+            style: .numbered
         )
-        let sut = GDSScreen(viewModel: viewModel)
+        let view = viewModel.createUIView() as? GDSList
+        let listStack = view?.subviews.first as? UIStackView
+        let firstRow = listStack?.arrangedSubviews.first(where: { $0.isAccessibilityElement })
         
-        sut.configureScrollViewAccessibility()
-        
-        let bodyItemStack = sut.scrollViewInnerStackView.arrangedSubviews.first as? UIStackView
-        #expect(bodyItemStack?.isAccessibilityElement == true)
+        #expect(firstRow?.accessibilityRespondsToUserInteraction == true)
     }
     
-    @Test("First accessibility element in GDSList body responds to user interaction for Full Keyboard Access")
-    func scrollViewAccessibility_listBody() {
-        let viewModel = TestGDSScreenViewModel(
-            screenStyle: .top,
-            body: [GDSListViewModel(
-                title: GDSLocalisedString(stringKey: "test"),
-                items: [GDSLocalisedString(stringKey: "item1")],
-                style: .numbered
-            )],
-            movableFooter: [],
-            footer: []
-        )
-        let sut = GDSScreen(viewModel: viewModel)
-        
-        sut.configureScrollViewAccessibility()
-        
-        let bodyItemStack = sut.scrollViewInnerStackView.arrangedSubviews.first as? UIStackView
-        #expect(bodyItemStack?.isAccessibilityElement == true)
-    }
-    
-    @Test("Empty body does not crash when configuring scroll view accessibility")
-    func scrollViewAccessibility_emptyBody() {
-        let viewModel = TestGDSScreenViewModel(
-            screenStyle: .top,
-            body: [],
-            movableFooter: [],
-            footer: []
-        )
-        let sut = GDSScreen(viewModel: viewModel)
-        sut.configureScrollViewAccessibility()
+    @Test("ContentView without accessibility elements does not crash")
+    func contentView_noAccessibilityElements() {
+        let viewModel = GDSTextViewModel(title: "test text")
+        // Should not crash even if isAccessibilityElement is false in test environment
+        _ = viewModel.createUIView()
     }
 }

--- a/Tests/DesignSystemTests/Views/GDSRow/GDSRowTests.swift
+++ b/Tests/DesignSystemTests/Views/GDSRow/GDSRowTests.swift
@@ -123,7 +123,7 @@ struct GDSRowTests {
         #expect(iconView.image?.isSymbolImage == true)
         #expect(iconView.tintColor == .secondaryLabel)
         
-        #expect(sut.accessibilityLabel == ("\(expectedTitle), \(expectedSubtitle), \(expectedIconAltText)"))
+        #expect(sut.accessibilityLabel == ("\(expectedTitle), \(expectedSubtitle)"))
         #expect(sut.accessibilityHint == ("icon alt text"))
         #expect(sut.accessibilityTraits == [.button])
     }


### PR DESCRIPTION
# DCMAW-17896 & DCMAW-19099 Remove double announcement of `opens in webbrowser` and ensure all content views are accessible via full keyboard access in scrollviews 

Currently accessibility hint is added twice. Remove the one that is not relating to the icon.

Also implemented scrollview accessibility workaround 

All views in scrollview accessible via full keyboard access:
https://github.com/user-attachments/assets/d5331563-0196-41d4-90ec-a41e135dab37


Single announcement of "Opens in web browser":
https://github.com/user-attachments/assets/393d6554-3eb3-40ca-9bd1-2e88157661b5




# Checklist

## Before raising your pull request:
- [x] Ran and tested the app locally ensuring it builds
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
