### PR TITLE
feat: DCMAW-20015 create GDSOrientationLockingTabBarController

### DIFF
--- a/Sources/Patterns/Protocols/GDSOrientationLockingTabBarController.swift
+++ b/Sources/Patterns/Protocols/GDSOrientationLockingTabBarController.swift
@@ -4,8 +4,8 @@ public protocol GDSOrientationLockingNavigationController: UINavigationControlle
     // Empty implementation
 }
 
-// OrientationLockingTabBarController prevents interface rotation preferences being overridden by UITabBarController.
-// It ensures the correct view controller handles rotation.
+/// GDSOrientationLockingTabBarController prevents interface rotation preferences being overridden by UITabBarController.
+/// It ensures the correct view controller handles rotation.
 public class GDSOrientationLockingTabBarController: UITabBarController {
     override open var shouldAutorotate: Bool {
         if let vc = self.selectedViewController?.presentedViewController, vc is GDSOrientationLockingNavigationController {

--- a/Sources/Patterns/Protocols/GDSOrientationLockingTabBarController.swift
+++ b/Sources/Patterns/Protocols/GDSOrientationLockingTabBarController.swift
@@ -1,0 +1,41 @@
+import UIKit
+
+public protocol GDSOrientationLockingNavigationController: UINavigationController {
+    // Empty implementation
+}
+
+// OrientationLockingTabBarController prevents interface rotation preferences being overridden by UITabBarController.
+// It ensures the correct view controller handles rotation.
+public class GDSOrientationLockingTabBarController: UITabBarController {
+    override open var shouldAutorotate: Bool {
+        if let vc = self.selectedViewController?.presentedViewController, vc is GDSOrientationLockingNavigationController {
+            return vc.shouldAutorotate
+        } else {
+            return super.shouldAutorotate
+        }
+    }
+    
+    override open var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        if let vc = self.selectedViewController?.presentedViewController, vc is GDSOrientationLockingNavigationController {
+            return vc.preferredInterfaceOrientationForPresentation
+        } else {
+            return super.preferredInterfaceOrientationForPresentation
+        }
+    }
+    
+    override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        if let vc = self.selectedViewController?.presentedViewController, vc is GDSOrientationLockingNavigationController {
+            return vc.supportedInterfaceOrientations
+        } else {
+            return super.supportedInterfaceOrientations
+        }
+    }
+    
+    override open var preferredStatusBarStyle: UIStatusBarStyle {
+        if let vc = self.selectedViewController?.presentedViewController, vc is GDSOrientationLockingNavigationController {
+            return vc.preferredStatusBarStyle
+        } else {
+            return super.preferredStatusBarStyle
+        }
+    }
+}

--- a/Tests/Patterns/GDSOrientationLockingTabBarControllerTests.swift
+++ b/Tests/Patterns/GDSOrientationLockingTabBarControllerTests.swift
@@ -133,15 +133,6 @@ struct GDSOrientationLockingTabBarControllerTests {
 class MockOrientationLockingViewController: UINavigationController, GDSOrientationLockingNavigationController {
     let shouldAutorotateValue: Bool
     
-    init(shouldAutorotate: Bool = false) {
-        shouldAutorotateValue = shouldAutorotate
-        super.init(nibName: nil, bundle: nil)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
     override var shouldAutorotate: Bool {
         shouldAutorotateValue
     }
@@ -156,5 +147,14 @@ class MockOrientationLockingViewController: UINavigationController, GDSOrientati
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
         .darkContent
+    }
+    
+    init(shouldAutorotate: Bool = false) {
+        shouldAutorotateValue = shouldAutorotate
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }

--- a/Tests/Patterns/GDSOrientationLockingTabBarControllerTests.swift
+++ b/Tests/Patterns/GDSOrientationLockingTabBarControllerTests.swift
@@ -1,0 +1,160 @@
+@testable import DesignSystem
+import Testing
+import UIKit
+
+@MainActor
+struct GDSOrientationLockingTabBarControllerTests {
+    let sut = GDSOrientationLockingTabBarController()
+    let navigationController = UINavigationController()
+    let orientationLockingViewController = MockOrientationLockingViewController()
+    let viewController = UIViewController()
+    
+    // MARK: For the following tests result of OrientationLockingTabBarController should match OrientationLockingViewController
+    @Test("Screen should not autorotate")
+    func test_shouldNotAutorotate() {
+        sut.setViewControllers([navigationController], animated: true)
+        sut.attachToWindow()
+        sut.selectedViewController = navigationController
+
+        let orientationLockingViewController = MockOrientationLockingViewController(shouldAutorotate: false)
+        
+        // Present OrientationLockingViewController modally
+        navigationController.present(orientationLockingViewController, animated: false)
+        
+        // TabBarController rotation should match MockOrientationLockingViewController rotation
+        #expect(sut.shouldAutorotate == false)
+    }
+    
+    @Test("Screen should autorotate")
+    func test_shouldAutorotate() {
+        sut.setViewControllers([navigationController], animated: true)
+        sut.attachToWindow()
+        sut.selectedViewController = navigationController
+        let orientationLockingViewController = MockOrientationLockingViewController(shouldAutorotate: true)
+        
+        // Present OrientationLockingViewController modally
+        navigationController.present(orientationLockingViewController, animated: true)
+        
+        // TabBarController rotation should match MockOrientationLockingViewController rotation
+        #expect(sut.shouldAutorotate == true)
+    }
+    
+    @Test("Screens preferredInterfaceOrientationForPresentation should match mock")
+    func test_preferredInterfaceOrientationForPresentation() {
+        sut.setViewControllers([navigationController], animated: true)
+        sut.attachToWindow()
+        sut.selectedViewController = navigationController
+        
+        // Present OrientationLockingViewController modally
+        navigationController.present(orientationLockingViewController, animated: false)
+        
+        // TabBarController rotation should match MockOrientationLockingViewController rotation
+        #expect(sut.preferredInterfaceOrientationForPresentation == .landscapeLeft)
+    }
+    
+    @Test("Screens supportedInterfaceOrientations should match mock")
+    func test_supportedInterfaceOrientations() {
+        sut.setViewControllers([navigationController], animated: true)
+        sut.attachToWindow()
+        sut.selectedViewController = navigationController
+        
+        // Present OrientationLockingViewController modally
+        navigationController.present(orientationLockingViewController, animated: false)
+        
+        // TabBarController rotation should match MockOrientationLockingViewController rotation
+        #expect(sut.supportedInterfaceOrientations == .landscapeLeft)
+    }
+    
+    @Test("Screens preferredStatusBarStyle should match mock")
+    func test_preferredStatusBarStyle() {
+        sut.setViewControllers([navigationController], animated: true)
+        sut.attachToWindow()
+        sut.selectedViewController = navigationController
+        
+        // Present OrientationLockingViewController modally
+        navigationController.present(orientationLockingViewController, animated: false)
+        
+        // TabBarController rotation should match MockOrientationLockingViewController rotation
+        #expect(sut.preferredStatusBarStyle == .darkContent)
+    }
+    
+    // MARK: For the following tests result of OrientationLockingTabBarController should match default behaviour of UITabBarController
+    @Test("Test default screen rotation")
+    func test_default_shouldAutorotate() {
+        sut.setViewControllers([navigationController], animated: true)
+        sut.attachToWindow()
+        sut.selectedViewController = navigationController
+        
+        // Present a UIViewController modally
+        navigationController.present(viewController, animated: false)
+        
+        #expect(sut.shouldAutorotate == UITabBarController().shouldAutorotate)
+    }
+    
+    @Test("Test default preferredInterfaceOrientationForPresentation")
+    func test_default_preferredInterfaceOrientationForPresentation() {
+        sut.setViewControllers([navigationController], animated: true)
+        sut.attachToWindow()
+        sut.selectedViewController = navigationController
+        
+        // Present a UIViewController modally
+        navigationController.present(viewController, animated: false)
+        
+        // Since the UIViewController is being presented modally
+        // This value value will not be set and will be .unknown
+        #expect(sut.preferredInterfaceOrientationForPresentation == .unknown)
+    }
+    
+    @Test("Test default supportedInterfaceOrientations")
+    func test_default_supportedInterfaceOrientations() {
+        sut.setViewControllers([navigationController], animated: true)
+        sut.attachToWindow()
+        sut.selectedViewController = navigationController
+        
+        // Present a UIViewController modally
+        navigationController.present(viewController, animated: false)
+        
+        #expect(sut.supportedInterfaceOrientations == UITabBarController().supportedInterfaceOrientations)
+    }
+    
+    @Test("Test default preferredStatusBarStyle")
+    func test_default_preferredStatusBarStyle() {
+        sut.setViewControllers([navigationController], animated: true)
+        sut.attachToWindow()
+        sut.selectedViewController = navigationController
+        
+        // Present a UIViewController modally
+        navigationController.present(viewController, animated: false)
+        
+        #expect(sut.preferredStatusBarStyle == UITabBarController().preferredStatusBarStyle)
+    }
+}
+
+class MockOrientationLockingViewController: UINavigationController, GDSOrientationLockingNavigationController {
+    let shouldAutorotateValue: Bool
+    
+    init(shouldAutorotate: Bool = false) {
+        shouldAutorotateValue = shouldAutorotate
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override var shouldAutorotate: Bool {
+        shouldAutorotateValue
+    }
+    
+    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        .landscapeLeft
+    }
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        .landscapeLeft
+    }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        .darkContent
+    }
+}

--- a/Tests/TestExtensions/UIColorExtensionTests.swift
+++ b/Tests/TestExtensions/UIColorExtensionTests.swift
@@ -18,6 +18,4 @@ struct UIColorExtensionTests {
     @Test func test_Color_lightColor() {
         #expect(UIColor.fromHex("#FF0000").lightColor == .red)
     }
-
-    
 }

--- a/Tests/TestExtensions/UIViewController+Extensions.swift
+++ b/Tests/TestExtensions/UIViewController+Extensions.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+extension UIViewController {
+    func attachToWindow() {
+        let window = UIWindow()
+        window.rootViewController = self
+        window.makeKeyAndVisible()
+    }
+}


### PR DESCRIPTION
# feat: DCMAW-20015 create GDSOrientationLockingTabBarController

This PR copies over GDSOrientationLockingTabBarController from GDSCommon https://github.com/govuk-one-login/mobile-ios-common/blob/main/Sources/GDSCommon/Utilities/OrientationLockingTabBarController.swift

This type is used to prevent UITabBarController overriding the displaying viewController rotation preferences, OrientationLockingTabBarController ensures the correct viewController handles rotation. This is used by OneLogin and IDCheck to prevent vendor screens from rotating 

# Checklist

## Before raising your pull request:
- [x] Ran and tested the app locally ensuring it builds
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
