### PR TITLE
feat: DCMAW-20467 - Enable accessibility hint override

### DIFF
--- a/Sources/Components/GDSWarningText/GDSWarningTextViewModel.swift
+++ b/Sources/Components/GDSWarningText/GDSWarningTextViewModel.swift
@@ -17,7 +17,12 @@ public struct GDSWarningTextViewModel: ContentViewModel {
     public var horizontalPadding: HorizontalPadding?
     
     public var accessibilityLabel: String {
-        "\(NSLocalizedString(key: "voiceOverWarningPrefix", bundle: .designSystem)): \(warningText.title)"
+        let iconAccessibilityHint = iconStyle?.accessibilityHint ?? NSLocalizedString(
+            key: "voiceOverWarningPrefix",
+            bundle: .designSystem
+        )
+        
+        return "\(iconAccessibilityHint): \(warningText.title)"
     }
     
     public init(

--- a/Tests/Components/GDSWarningText/GDSWarningTextTests.swift
+++ b/Tests/Components/GDSWarningText/GDSWarningTextTests.swift
@@ -84,4 +84,33 @@ struct GDSWarningTextTests {
         
         #expect(viewModel.iconSpacing == CGFloat(DesignSystem.Spacing.GDSWarningText.default))
     }
+    
+    @Test("Test accessibilityLabel uses default warning prefix when iconStyle has no accessibilityHint")
+    func accessibilityLabelDefaultPrefix() {
+        let viewModel = GDSWarningTextViewModel(
+            warningText: GDSTextViewModel(title: "Something went wrong", titleFont: DesignSystem.Font.Base.calloutSemiBold)
+        )
+        
+        #expect(viewModel.accessibilityLabel == "Warning: Something went wrong")
+    }
+    
+    @Test("Test accessibilityLabel uses custom accessibilityHint from iconStyle")
+    func accessibilityLabelCustomHint() {
+        let viewModel = GDSWarningTextViewModel(
+            iconStyle: IconStyle(icon: "info.circle", position: .leading, accessibilityHint: "Important"),
+            warningText: GDSTextViewModel(title: "Check your details", titleFont: DesignSystem.Font.Base.calloutSemiBold)
+        )
+        
+        #expect(viewModel.accessibilityLabel == "Important: Check your details")
+    }
+    
+    @Test("Test accessibilityLabel uses default warning prefix when iconStyle is nil")
+    func accessibilityLabelNilIconStyle() {
+        let viewModel = GDSWarningTextViewModel(
+            iconStyle: nil,
+            warningText: GDSTextViewModel(title: "Please try again", titleFont: DesignSystem.Font.Base.calloutSemiBold)
+        )
+        
+        #expect(viewModel.accessibilityLabel == "Warning: Please try again")
+    }
 }


### PR DESCRIPTION
# Enable accessibility hint override on GDSWarningTextViewModel

https://govukverify.atlassian.net/browse/DCMAW-20467

Summary
  
  Updates GDSWarningTextViewModel.accessibilityLabel to use the IconStyle.accessibilityHint when provided, falling back to the localised "Warning" prefix. This
  allows consumers to customise the VoiceOver prefix for different icon contexts.
  
  Changes
  
  - GDSWarningTextViewModel — accessibilityLabel now reads from iconStyle?.accessibilityHint before falling back to the localised voiceOverWarningPrefix string
  - GDSWarningTextTests — Added 3 tests covering:
    - Default prefix when icon style has no accessibility hint
    - Custom prefix via IconStyle.accessibilityHint
    - Default prefix when iconStyle is nil
 


# Checklist

## Before raising your pull request:
- [x] Ran and tested the app locally ensuring it builds
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
