### PR TITLE
fix: added ControlViewModel that allows enabling / disabling of buttons

### DIFF
--- a/Demo/DesignSystemDemo/ViewController.swift
+++ b/Demo/DesignSystemDemo/ViewController.swift
@@ -84,7 +84,7 @@ class ViewController: UIViewController {
 // MARK: - View Models
 
 extension ViewController {
-    private static let controlledButton = GDSButtonViewModel(
+    private let controlledButton = GDSButtonViewModel(
         title: TitleForState(normal: "Button enabled", disabled: "Button disabled"),
         style: .primary,
         buttonAction: .action({ }),
@@ -96,11 +96,11 @@ extension ViewController {
             GDSButtonViewModel(
                 title: "Toggle button below",
                 style: .primary,
-                buttonAction: .action({
-                    Self.controlledButton.isEnabledToggle()
+                buttonAction: .action({ [weak self] in
+                    self?.controlledButton.isEnabledToggle()
                 })
             ),
-            Self.controlledButton,
+            controlledButton,
             GDSProgressIndicatorViewModel(),
             GDSButtonViewModel(
                 title: "Push GDSScreen",

--- a/Demo/DesignSystemDemo/ViewController.swift
+++ b/Demo/DesignSystemDemo/ViewController.swift
@@ -84,20 +84,23 @@ class ViewController: UIViewController {
 // MARK: - View Models
 
 extension ViewController {
-    private let controlledButton = GDSButtonViewModel(
-        title: TitleForState(normal: "Button enabled", disabled: "Button disabled"),
-        style: .primary,
-        buttonAction: .action({ }),
-        enableState: false
-    )
-    
     var bodyContent: [any ContentViewModel] {
-        [
+        let controlledButton = GDSButtonViewModel(
+            title: TitleForState(normal: "Button enabled", disabled: "Button disabled"),
+            style: .primary,
+            buttonAction: .action({ [weak self] in
+                let alert = UIAlertController(title: "Enabled!", message: nil, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default))
+                self?.present(alert, animated: true)
+            }),
+            enableState: false
+        )
+        return [
             GDSButtonViewModel(
                 title: "Toggle button below",
                 style: .primary,
-                buttonAction: .action({ [weak self] in
-                    self?.controlledButton.isEnabledToggle()
+                buttonAction: .action({
+                    controlledButton.isEnabledToggle()
                 })
             ),
             controlledButton,

--- a/Demo/DesignSystemDemo/ViewController.swift
+++ b/Demo/DesignSystemDemo/ViewController.swift
@@ -84,8 +84,23 @@ class ViewController: UIViewController {
 // MARK: - View Models
 
 extension ViewController {
+    private static let controlledButton = GDSButtonViewModel(
+        title: TitleForState(normal: "Button enabled", disabled: "Button disabled"),
+        style: .primary,
+        buttonAction: .action({ }),
+        enableState: false
+    )
+    
     var bodyContent: [any ContentViewModel] {
         [
+            GDSButtonViewModel(
+                title: "Toggle button below",
+                style: .primary,
+                buttonAction: .action({
+                    Self.controlledButton.isEnabledToggle()
+                })
+            ),
+            Self.controlledButton,
             GDSProgressIndicatorViewModel(),
             GDSButtonViewModel(
                 title: "Push GDSScreen",

--- a/Sources/Components/ContentView.swift
+++ b/Sources/Components/ContentView.swift
@@ -12,10 +12,16 @@ extension ContentViewModel {
     public func createUIView() -> UIView {
         let view = ViewType(viewModel: self)
         Self.enableAccessibilityInteraction(in: view)
+        if let controlVM = self as? ControlViewModel,
+           let control = view as? UIControl,
+           let enableState = controlVM.enableState {
+            control.isEnabled = enableState.isEnabled
+            enableState.onChange = { [weak control] in control?.isEnabled = $0 }
+        }
         return view
     }
     
-    private static func enableAccessibilityInteraction(in view: UIView) {
+    static func enableAccessibilityInteraction(in view: UIView) {
         if view.isAccessibilityElement {
             view.accessibilityRespondsToUserInteraction = true
             return

--- a/Sources/Components/ContentView.swift
+++ b/Sources/Components/ContentView.swift
@@ -6,18 +6,14 @@ public protocol ContentViewModel {
     
     var verticalPadding: VerticalPadding? { get }
     var horizontalPadding: HorizontalPadding? { get }
+    
+    func createUIView() -> UIView
 }
 
 extension ContentViewModel {
     public func createUIView() -> UIView {
         let view = ViewType(viewModel: self)
         Self.enableAccessibilityInteraction(in: view)
-        if let controlVM = self as? ControlViewModel,
-           let control = view as? UIControl,
-           let enableState = controlVM.enableState {
-            control.isEnabled = enableState.isEnabled
-            enableState.onChange = { [weak control] in control?.isEnabled = $0 }
-        }
         return view
     }
     
@@ -29,6 +25,19 @@ extension ContentViewModel {
         for subview in view.subviews {
             enableAccessibilityInteraction(in: subview)
         }
+    }
+}
+
+extension ContentViewModel where Self: ControlViewModel {
+    public func createUIView() -> UIView {
+        let view = ViewType(viewModel: self)
+        Self.enableAccessibilityInteraction(in: view)
+        if let control = view as? UIControl,
+           let enableState = self.enableState {
+            control.isEnabled = enableState.isEnabled
+            enableState.onChange = { [weak control] in control?.isEnabled = $0 }
+        }
+        return view
     }
 }
 

--- a/Sources/Components/ControlViewModel.swift
+++ b/Sources/Components/ControlViewModel.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+@MainActor
+public protocol ControlViewModel {
+    var enableState: EnableState? { get }
+}
+
+extension ControlViewModel {
+    public var enableState: EnableState? { nil }
+    
+    public func isEnabledToggle() {
+        enableState?.isEnabled.toggle()
+    }
+    
+    public func enable() {
+        enableState?.isEnabled = true
+    }
+    
+    public func disable() {
+        enableState?.isEnabled = false
+    }
+}

--- a/Sources/Components/EnableState.swift
+++ b/Sources/Components/EnableState.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+@MainActor
+public final class EnableState {
+    public var isEnabled: Bool {
+        didSet { onChange?(isEnabled) }
+    }
+    var onChange: ((Bool) -> Void)?
+
+    public init(_ isEnabled: Bool = true) {
+        self.isEnabled = isEnabled
+    }
+}

--- a/Sources/Components/GDSButton/GDSButtonViewModel.swift
+++ b/Sources/Components/GDSButton/GDSButtonViewModel.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public struct GDSButtonViewModel: ContentViewModel {
+public struct GDSButtonViewModel: ContentViewModel, ControlViewModel {
     public typealias ViewType = GDSButton
     
     public let title: TitleForState
@@ -10,6 +10,7 @@ public struct GDSButtonViewModel: ContentViewModel {
     public let haptic: Haptic?
     public let accessibilityIdentifier: String?
     public let accessibilityHint: String?
+    public let enableState: EnableState?
     public let verticalPadding: VerticalPadding?
     public let horizontalPadding: HorizontalPadding?
     
@@ -21,6 +22,7 @@ public struct GDSButtonViewModel: ContentViewModel {
         haptic: Haptic? = nil,
         accessibilityIdentifier: String? = nil,
         accessibilityHint: String? = nil,
+        enableState: Bool? = nil,
         verticalPadding: VerticalPadding? = .vertical(0),
         horizontalPadding: HorizontalPadding? = .horizontal(0)
     ) {
@@ -35,6 +37,13 @@ public struct GDSButtonViewModel: ContentViewModel {
         self.haptic = haptic
         self.accessibilityIdentifier = accessibilityIdentifier
         self.accessibilityHint = accessibilityHint
+        
+        if let enableState {
+            self.enableState = EnableState(enableState)
+        } else {
+            self.enableState = nil
+        }
+        
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
     }
@@ -47,6 +56,7 @@ public struct GDSButtonViewModel: ContentViewModel {
         haptic: Haptic? = nil,
         accessibilityIdentifier: String? = nil,
         accessibilityHint: String? = nil,
+        enableState: Bool? = nil,
         verticalPadding: VerticalPadding? = .vertical(0),
         horizontalPadding: HorizontalPadding? = .horizontal(0)
     ) {
@@ -57,6 +67,13 @@ public struct GDSButtonViewModel: ContentViewModel {
         self.haptic = haptic
         self.accessibilityIdentifier = accessibilityIdentifier
         self.accessibilityHint = accessibilityHint
+        
+        if let enableState {
+            self.enableState = EnableState(enableState)
+        } else {
+            self.enableState = nil
+        }
+        
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
     }

--- a/Tests/Components/EnableStateTests.swift
+++ b/Tests/Components/EnableStateTests.swift
@@ -1,0 +1,107 @@
+@testable @_spi(unstable) import DesignSystem
+import Testing
+import UIKit
+
+@MainActor
+struct EnableStateTests {
+    @Test func defaultsToEnabled() {
+        let sut = EnableState()
+        #expect(sut.isEnabled == true)
+    }
+    
+    @Test func canBeInitialisedAsDisabled() {
+        let sut = EnableState(false)
+        #expect(sut.isEnabled == false)
+    }
+    
+    @Test func onChangeCalledWhenValueChanges() {
+        let sut = EnableState(true)
+        var received: Bool?
+        sut.onChange = { received = $0 }
+        
+        sut.isEnabled = false
+        #expect(received == false)
+    }
+    
+    @Test func onChangeCalledOnEverySet() {
+        let sut = EnableState(true)
+        var callCount = 0
+        sut.onChange = { _ in callCount += 1 }
+        
+        sut.isEnabled = true
+        #expect(callCount == 1)
+    }
+}
+
+@MainActor
+struct ControlViewModelTests {
+    @Test func buttonStartsDisabledWhenEnableStateIsFalse() {
+        let viewModel = GDSButtonViewModel(
+            title: "Test",
+            style: .primary,
+            buttonAction: .action({ }),
+            enableState: false
+        )
+        
+        let view = viewModel.createUIView()
+        let button = view as? GDSButton
+        #expect(button?.isEnabled == false)
+    }
+    
+    @Test func buttonStartsEnabledWhenEnableStateIsTrue() {
+        let viewModel = GDSButtonViewModel(
+            title: "Test",
+            style: .primary,
+            buttonAction: .action({ }),
+            enableState: true
+        )
+        
+        let view = viewModel.createUIView()
+        let button = view as? GDSButton
+        #expect(button?.isEnabled == true)
+    }
+    
+    @Test func buttonStartsEnabledWhenNoEnableState() {
+        let viewModel = GDSButtonViewModel(
+            title: "Test",
+            style: .primary,
+            buttonAction: .action({ })
+        )
+        
+        let view = viewModel.createUIView()
+        let button = view as? GDSButton
+        #expect(button?.isEnabled == true)
+    }
+    
+    @Test func buttonEnablesWhenEnableStateChanges() {
+        let viewModel = GDSButtonViewModel(
+            title: "Test",
+            style: .primary,
+            buttonAction: .action({ }),
+            enableState: false
+        )
+        
+        let view = viewModel.createUIView()
+        let button = view as? GDSButton
+        #expect(button?.isEnabled == false)
+        
+        viewModel.enable()
+        #expect(button?.isEnabled == true)
+    }
+    
+    @Test func buttonDisablesWhenEnableStateChanges() {
+        let viewModel = GDSButtonViewModel(
+            title: "Test",
+            style: .primary,
+            buttonAction: .action({ }),
+            enableState: true
+        )
+        
+        let view = viewModel.createUIView()
+        let button = view as? GDSButton
+        #expect(button?.isEnabled == true)
+        
+        viewModel.disable()
+        #expect(button?.isEnabled == false)
+    }
+}


### PR DESCRIPTION
# Allow UIControl classes created via `ContentViewModel` to be enabled and disabled 

Currently buttons are not able to be enabled and disabled without subclassing `GDSScreen` and reaching into the nested hierarchy of the subviews of the view controller's `view`.


With this work:
https://github.com/user-attachments/assets/2596b356-7100-4097-9653-30c898db22a7


# Checklist

## Before raising your pull request:
- [x] Ran and tested the app locally ensuring it builds
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
