### PR TITLE
fix: DCMAW-20958 add accessibility identifier to `GDSTextViewModel` and `GDSButtonViewModel`

### DIFF
--- a/Sources/Components/GDSButton/GDSButton.swift
+++ b/Sources/Components/GDSButton/GDSButton.swift
@@ -47,6 +47,8 @@ public final class GDSButton: UIButton, ContentView {
                 ]
             )
         }
+        
+        self.accessibilityIdentifier = viewModel.accessibilityIdentifier
     }
     
     required init?(coder: NSCoder) {

--- a/Sources/Components/GDSButton/GDSButtonViewModel.swift
+++ b/Sources/Components/GDSButton/GDSButtonViewModel.swift
@@ -8,6 +8,7 @@ public struct GDSButtonViewModel: ContentViewModel {
     public let style: GDSButtonStyle
     public let buttonAction: DesignSystem.Action
     public let haptic: Haptic?
+    public let accessibilityIdentifier: String?
     public let accessibilityHint: String?
     public let verticalPadding: VerticalPadding?
     public let horizontalPadding: HorizontalPadding?
@@ -18,6 +19,7 @@ public struct GDSButtonViewModel: ContentViewModel {
         style: GDSButtonStyle,
         buttonAction: DesignSystem.Action,
         haptic: Haptic? = nil,
+        accessibilityIdentifier: String? = nil,
         accessibilityHint: String? = nil,
         verticalPadding: VerticalPadding? = .vertical(0),
         horizontalPadding: HorizontalPadding? = .horizontal(0)
@@ -31,6 +33,7 @@ public struct GDSButtonViewModel: ContentViewModel {
         self.style = style
         self.buttonAction = buttonAction
         self.haptic = haptic
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.accessibilityHint = accessibilityHint
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
@@ -42,6 +45,7 @@ public struct GDSButtonViewModel: ContentViewModel {
         style: GDSButtonStyle,
         buttonAction: DesignSystem.Action,
         haptic: Haptic? = nil,
+        accessibilityIdentifier: String? = nil,
         accessibilityHint: String? = nil,
         verticalPadding: VerticalPadding? = .vertical(0),
         horizontalPadding: HorizontalPadding? = .horizontal(0)
@@ -51,6 +55,7 @@ public struct GDSButtonViewModel: ContentViewModel {
         self.style = style
         self.buttonAction = buttonAction
         self.haptic = haptic
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.accessibilityHint = accessibilityHint
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding

--- a/Sources/Components/GDSText/GDSTextView.swift
+++ b/Sources/Components/GDSText/GDSTextView.swift
@@ -18,7 +18,7 @@ public final class GDSTextView: UILabel, ContentView {
         if let accessibilityTraits = viewModel.accessibilityTraits {
             self.accessibilityTraits = accessibilityTraits
         }
-        self.accessibilityIdentifier = "gds-text-view"
+        self.accessibilityIdentifier = viewModel.accessibilityIdentifier ?? "gds-text-view"
     }
     
     required init?(coder: NSCoder) {

--- a/Sources/Components/GDSText/GDSTextViewModel.swift
+++ b/Sources/Components/GDSText/GDSTextViewModel.swift
@@ -8,7 +8,8 @@ public struct GDSTextViewModel: ContentViewModel {
     let textColor: UIColor
     let alignment: NSTextAlignment
     let accessibilityTraits: UIAccessibilityTraits?
-    
+    let accessibilityIdentifier: String?
+
     public let verticalPadding: VerticalPadding?
     public let horizontalPadding: HorizontalPadding?
     
@@ -18,6 +19,7 @@ public struct GDSTextViewModel: ContentViewModel {
         textColor: UIColor = DesignSystem.Color.Text.primary,
         alignment: NSTextAlignment = .left,
         accessibilityTraits: UIAccessibilityTraits? = nil,
+        accessibilityIdentifier: String? = nil,
         verticalPadding: VerticalPadding? = .vertical(8),
         horizontalPadding: HorizontalPadding? = .horizontal(16)
     ) {
@@ -26,6 +28,7 @@ public struct GDSTextViewModel: ContentViewModel {
         self.textColor = textColor
         self.alignment = alignment
         self.accessibilityTraits = accessibilityTraits
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
     }

--- a/Tests/Components/GDSButton/GDSButtonTests.swift
+++ b/Tests/Components/GDSButton/GDSButtonTests.swift
@@ -237,4 +237,20 @@ struct GDSButtonTests {
         
         #expect(sut.accessibilityHint == "custom hint")
     }
+    
+    @Test("Button has custom accessibility identifier")
+    func buttonCustomAccessibilityIdentifier() {
+        let viewModel = GDSButtonViewModel(
+            title: TitleForState(normal: "test title"),
+            icon: nil,
+            style: .secondary,
+            buttonAction: .action({}),
+            accessibilityIdentifier: "any identifier"
+        )
+        let sut = GDSButton(viewModel: viewModel)
+        // normally gets invoked by UIKit so we need to call manually here
+        sut.configurationUpdateHandler?(sut)
+        
+        #expect(sut.accessibilityIdentifier == "any identifier")
+   }
 }

--- a/Tests/Components/GDSText/GDSTextTests.swift
+++ b/Tests/Components/GDSText/GDSTextTests.swift
@@ -37,4 +37,14 @@ struct GDSTextTests {
         #expect(sut.textAlignment == .center)
         #expect(sut.accessibilityTraits == .header)
     }
+    
+    @Test("TextView has custom accessibility identifier")
+    func textViewCustomAccessibilityIdentifier() {
+        let viewModel = GDSTextViewModel(
+            title: "test title",
+            accessibilityIdentifier: "any identifier"
+        )
+        let sut = GDSTextView(viewModel: viewModel)
+        #expect(sut.accessibilityIdentifier == "any identifier")
+    }
 }


### PR DESCRIPTION
# Allow for an accessibility identifier to be set

New functionality to specify an accessibility identifier. This addition is primarily driven by the need to write (and update existing) UI Tests.

This work was carried out as part of the [iOS | Tech Debt | Ensure Login UI Tests still pass when using the Design System](https://govukverify.atlassian.net/browse/DCMAW-20958) to fix the failing [Manual UI Test workflow](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/workflows/nightly-ui-test.yml).

# Checklist

## Before raising your pull request:
- [x] Ran and tested the app locally ensuring it builds
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
