### PR TITLE
fix: DCMAW-20958 expose accessibility identifier

### DIFF
--- a/Sources/Components/ContentView.swift
+++ b/Sources/Components/ContentView.swift
@@ -13,6 +13,11 @@ public protocol ContentViewModel {
 }
 
 extension ContentViewModel {
+    var accessibilityIdentifier: String? { nil }
+    var accessibilityTraits: UIAccessibilityTraits? { nil }
+}
+
+extension ContentViewModel {
     public func createUIView() -> UIView {
         let view = ViewType(viewModel: self)
         Self.enableAccessibilityInteraction(in: view)

--- a/Sources/Components/ContentView.swift
+++ b/Sources/Components/ContentView.swift
@@ -6,6 +6,8 @@ public protocol ContentViewModel {
     
     var verticalPadding: VerticalPadding? { get }
     var horizontalPadding: HorizontalPadding? { get }
+    var accessibilityIdentifier: String? { get }
+    var accessibilityTraits: UIAccessibilityTraits? { get }
     
     func createUIView() -> UIView
 }

--- a/Sources/Components/GDSButton/GDSButtonViewModel.swift
+++ b/Sources/Components/GDSButton/GDSButtonViewModel.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 public struct GDSButtonViewModel: ContentViewModel, ControlViewModel {
+    
     public typealias ViewType = GDSButton
     
     public let title: TitleForState
@@ -10,6 +11,7 @@ public struct GDSButtonViewModel: ContentViewModel, ControlViewModel {
     public let haptic: Haptic?
     public let accessibilityIdentifier: String?
     public let accessibilityHint: String?
+    public let accessibilityTraits: UIAccessibilityTraits?
     public let enableState: EnableState?
     public let verticalPadding: VerticalPadding?
     public let horizontalPadding: HorizontalPadding?
@@ -22,6 +24,7 @@ public struct GDSButtonViewModel: ContentViewModel, ControlViewModel {
         haptic: Haptic? = nil,
         accessibilityIdentifier: String? = nil,
         accessibilityHint: String? = nil,
+        accessibilityTraits: UIAccessibilityTraits? = nil,
         enableState: Bool? = nil,
         verticalPadding: VerticalPadding? = .vertical(0),
         horizontalPadding: HorizontalPadding? = .horizontal(0)
@@ -37,6 +40,7 @@ public struct GDSButtonViewModel: ContentViewModel, ControlViewModel {
         self.haptic = haptic
         self.accessibilityIdentifier = accessibilityIdentifier
         self.accessibilityHint = accessibilityHint
+        self.accessibilityTraits = accessibilityTraits
         
         if let enableState {
             self.enableState = EnableState(enableState)
@@ -67,6 +71,7 @@ public struct GDSButtonViewModel: ContentViewModel, ControlViewModel {
         self.haptic = haptic
         self.accessibilityIdentifier = accessibilityIdentifier
         self.accessibilityHint = accessibilityHint
+        self.accessibilityTraits = nil
         
         if let enableState {
             self.enableState = EnableState(enableState)

--- a/Sources/Components/GDSCard/GDSCard.swift
+++ b/Sources/Components/GDSCard/GDSCard.swift
@@ -55,6 +55,10 @@ public final class GDSCard: UIView, ContentView {
     public init(viewModel: GDSCardViewModel) {
         self.viewModel = viewModel
         super.init(frame: .zero)
+        if let accessibilityTraits = viewModel.accessibilityTraits {
+            self.accessibilityTraits = accessibilityTraits
+        }
+        self.accessibilityIdentifier = viewModel.accessibilityIdentifier
         addStackToView()
     }
     

--- a/Sources/Components/GDSCard/GDSCardTitle/GDSCardTitle.swift
+++ b/Sources/Components/GDSCard/GDSCardTitle/GDSCardTitle.swift
@@ -21,7 +21,7 @@ public final class GDSCardTitleView: UIStackView, ContentView {
         if let accessibilityTraits = viewModel.accessibilityTraits {
             label.accessibilityTraits = accessibilityTraits
         }
-        label.accessibilityIdentifier = "content-card-title"
+        label.accessibilityIdentifier = viewModel.accessibilityIdentifier ?? "content-card-title"
         self.addArrangedSubview(paddingView)
         self.addArrangedSubview(label)
         self.axis = .vertical

--- a/Sources/Components/GDSCard/GDSCardTitle/GDSCardTitleViewModel.swift
+++ b/Sources/Components/GDSCard/GDSCardTitle/GDSCardTitleViewModel.swift
@@ -6,7 +6,8 @@ public struct GDSCardTitleViewModel: ContentViewModel {
     let title: GDSLocalisedString
     let titleFont: UIFont
     let alignment: NSTextAlignment
-    let accessibilityTraits: UIAccessibilityTraits?
+    public let accessibilityTraits: UIAccessibilityTraits?
+    public let accessibilityIdentifier: String?
     
     public let verticalPadding: VerticalPadding?
     public let horizontalPadding: HorizontalPadding?
@@ -16,6 +17,7 @@ public struct GDSCardTitleViewModel: ContentViewModel {
         titleFont: UIFont = DesignSystem.Font.Base.title2Bold,
         alignment: NSTextAlignment = .left,
         accessibilityTraits: UIAccessibilityTraits? = nil,
+        accessibilityIdentifier: String? = nil,
         verticalPadding: VerticalPadding? = .vertical(8),
         horizontalPadding: HorizontalPadding? = .horizontal(16)
     ) {
@@ -23,6 +25,7 @@ public struct GDSCardTitleViewModel: ContentViewModel {
         self.titleFont = titleFont
         self.alignment = alignment
         self.accessibilityTraits = accessibilityTraits
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
     }

--- a/Sources/Components/GDSCard/GDSCardViewModel.swift
+++ b/Sources/Components/GDSCard/GDSCardViewModel.swift
@@ -8,6 +8,8 @@ public struct GDSCardViewModel: ContentViewModel {
     let showShadow: Bool
     let dismissAction: DesignSystem.Action?
     
+    public let accessibilityIdentifier: String?
+    public let accessibilityTraits: UIAccessibilityTraits?
     public let verticalPadding: VerticalPadding?
     public let horizontalPadding: HorizontalPadding?
     
@@ -18,6 +20,8 @@ public struct GDSCardViewModel: ContentViewModel {
         borderStyle: BorderStyle? = nil,
         showShadow: Bool = false,
         dismissAction: DesignSystem.Action? = nil,
+        accessibilityIdentifier: String? = nil,
+        accessibilityTraits: UIAccessibilityTraits? = nil,
         verticalPadding: VerticalPadding? = .vertical(0),
         horizontalPadding: HorizontalPadding? = .horizontal(0),
         @ContentItemBuilder contentItems: () -> [any ContentViewModel]
@@ -26,6 +30,8 @@ public struct GDSCardViewModel: ContentViewModel {
         self.borderStyle = borderStyle
         self.showShadow = showShadow
         self.dismissAction = dismissAction
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.accessibilityTraits = accessibilityTraits
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
         self.contentItems = contentItems()

--- a/Sources/Components/GDSDivider/GDSDividerView.swift
+++ b/Sources/Components/GDSDivider/GDSDividerView.swift
@@ -7,7 +7,10 @@ public final class GDSDividerView: UIView, ContentView {
         self.backgroundColor = viewModel.colour
         let scale = 1 / UIScreen.main.scale
         self.heightAnchor.constraint(equalToConstant: (viewModel.height * scale)).isActive = true
-        self.accessibilityIdentifier = "gds-divider-view"
+        if let accessibilityTraits = viewModel.accessibilityTraits {
+            self.accessibilityTraits = accessibilityTraits
+        }
+        self.accessibilityIdentifier = viewModel.accessibilityIdentifier ?? "gds-divider-view"
     }
     
     required init?(coder: NSCoder) {

--- a/Sources/Components/GDSDivider/GDSDividerViewModel.swift
+++ b/Sources/Components/GDSDivider/GDSDividerViewModel.swift
@@ -6,17 +6,23 @@ public struct GDSDividerViewModel: ContentViewModel {
     let height: CGFloat
     let colour: UIColor
     
+    public let accessibilityIdentifier: String?
+    public let accessibilityTraits: UIAccessibilityTraits?
     public let verticalPadding: VerticalPadding?
     public let horizontalPadding: HorizontalPadding?
     
     public init(
         height: CGFloat = 1,
         colour: UIColor = DesignSystem.Color.Dividers.card,
+        accessibilityIdentifier: String? = nil,
+        accessibilityTraits: UIAccessibilityTraits? = nil,
         verticalPadding: VerticalPadding? = .vertical(8),
         horizontalPadding: HorizontalPadding? = .leading(16)
     ) {
         self.height = height
         self.colour = colour
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.accessibilityTraits = accessibilityTraits
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
     }

--- a/Sources/Components/GDSErrorIcon/GDSErrorIconTitle.swift
+++ b/Sources/Components/GDSErrorIcon/GDSErrorIconTitle.swift
@@ -33,8 +33,8 @@ public final class GDSErrorIconTitle: UIView, ContentView {
         stack.isAccessibilityElement = true
         stack.shouldGroupAccessibilityChildren = true
         stack.accessibilityLabel = viewModel.accessibilityLabel
-        stack.accessibilityTraits = viewModel.errorTitle.accessibilityTraits ?? [.header]
-        stack.accessibilityIdentifier = "error-screen-icon-title-stack-view"
+        stack.accessibilityTraits = viewModel.accessibilityTraits ?? viewModel.errorTitle.accessibilityTraits ?? [.header]
+        stack.accessibilityIdentifier = viewModel.accessibilityIdentifier ?? "error-screen-icon-title-stack-view"
         
         return stack
     }()

--- a/Sources/Components/GDSErrorIcon/GDSErrorIconTitleViewModel.swift
+++ b/Sources/Components/GDSErrorIcon/GDSErrorIconTitleViewModel.swift
@@ -7,6 +7,8 @@ public struct GDSErrorIconTitleViewModel: ContentViewModel {
     let iconHeight: CGFloat
     let errorTitle: GDSTextViewModel
     
+    public var accessibilityIdentifier: String?
+    public var accessibilityTraits: UIAccessibilityTraits?
     public var verticalPadding: VerticalPadding? = .vertical(DesignSystem.Spacing.default)
     public var horizontalPadding: HorizontalPadding? = .horizontal(DesignSystem.Spacing.default)
     public var renderedIconHeight: CGFloat {
@@ -20,11 +22,15 @@ public struct GDSErrorIconTitleViewModel: ContentViewModel {
     public init(
         icon: ErrorScreenIcon,
         iconHeight: CGFloat = DesignSystem.Size.GDSErrorIcon.iconTargetHeight,
-        errorTitle: GDSTextViewModel
+        errorTitle: GDSTextViewModel,
+        accessibilityIdentifier: String? = nil,
+        accessibilityTraits: UIAccessibilityTraits? = nil
     ) {
         self.icon = icon
         self.iconHeight = iconHeight
         self.errorTitle = errorTitle
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.accessibilityTraits = accessibilityTraits
     }
   
     public init(
@@ -34,6 +40,7 @@ public struct GDSErrorIconTitleViewModel: ContentViewModel {
         titleFont: UIFont = DesignSystem.Font.Base.body,
         textColor: UIColor = DesignSystem.Color.Text.primary,
         alignment: NSTextAlignment = .left,
+        accessibilityIdentifier: String? = nil,
         accessibilityTraits: UIAccessibilityTraits? = nil,
         verticalPadding: VerticalPadding? = .vertical(DesignSystem.Spacing.default),
         horizontalPadding: HorizontalPadding? = .horizontal(DesignSystem.Spacing.default)
@@ -50,7 +57,9 @@ public struct GDSErrorIconTitleViewModel: ContentViewModel {
         self.init(
             icon: icon,
             iconHeight: iconHeight,
-            errorTitle: titleViewModel
+            errorTitle: titleViewModel,
+            accessibilityIdentifier: accessibilityIdentifier,
+            accessibilityTraits: accessibilityTraits
         )
     }
 }

--- a/Sources/Components/GDSImage/GDSImageView.swift
+++ b/Sources/Components/GDSImage/GDSImageView.swift
@@ -28,8 +28,10 @@ public final class GDSImageView: UIImageView, ContentView {
             self.isAccessibilityElement = true
             self.accessibilityLabel = accessibilityLabel
         }
-        
-        self.accessibilityIdentifier = "gds-image-view"
+        if let accessibilityTraits = viewModel.accessibilityTraits {
+            self.accessibilityTraits = accessibilityTraits
+        }
+        self.accessibilityIdentifier = viewModel.accessibilityIdentifier ?? "gds-image-view"
     }
     
     required init?(coder: NSCoder) {

--- a/Sources/Components/GDSImage/GDSImageViewModel.swift
+++ b/Sources/Components/GDSImage/GDSImageViewModel.swift
@@ -11,6 +11,8 @@ public struct GDSImageViewModel: ContentViewModel {
     let cornerMask: CACornerMask?
     let accessibilityLabel: String?
     
+    public let accessibilityIdentifier: String?
+    public let accessibilityTraits: UIAccessibilityTraits?
     public let verticalPadding: VerticalPadding?
     public let horizontalPadding: HorizontalPadding?
     
@@ -26,6 +28,8 @@ public struct GDSImageViewModel: ContentViewModel {
         imageFixedHeight: CGFloat? = nil,
         cornerMask: CACornerMask? = nil,
         accessibilityLabel: String? = nil,
+        accessibilityIdentifier: String? = nil,
+        accessibilityTraits: UIAccessibilityTraits? = nil,
         verticalPadding: VerticalPadding? = .vertical(0),
         horizontalPadding: HorizontalPadding? = .horizontal(0)
     ) {
@@ -36,6 +40,8 @@ public struct GDSImageViewModel: ContentViewModel {
         self.imageFixedHeight = imageFixedHeight
         self.cornerMask = cornerMask
         self.accessibilityLabel = accessibilityLabel
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.accessibilityTraits = accessibilityTraits
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
     }

--- a/Sources/Components/GDSList/GDSList.swift
+++ b/Sources/Components/GDSList/GDSList.swift
@@ -96,6 +96,10 @@ public final class GDSList: UIView, ContentView {
         backgroundColor = .systemBackground
         addSubview(listStackView)
         listStackView.bindToSuperviewEdges()
+        if let accessibilityTraits = viewModel.accessibilityTraits {
+            self.accessibilityTraits = accessibilityTraits
+        }
+        self.accessibilityIdentifier = viewModel.accessibilityIdentifier
         reloadListView()
     }
     

--- a/Sources/Components/GDSList/GDSListViewModel.swift
+++ b/Sources/Components/GDSList/GDSListViewModel.swift
@@ -15,6 +15,8 @@ public struct GDSListViewModel: ContentViewModel {
     public var titleConfig: TitleConfig?
     public var items: [GDSLocalisedString]
     public var style: ListStyle
+    public var accessibilityIdentifier: String?
+    public var accessibilityTraits: UIAccessibilityTraits?
     public var verticalPadding: VerticalPadding?
     public var horizontalPadding: HorizontalPadding?
     
@@ -23,6 +25,8 @@ public struct GDSListViewModel: ContentViewModel {
         titleConfig: TitleConfig? = nil,
         items: [GDSLocalisedString],
         style: ListStyle,
+        accessibilityIdentifier: String? = nil,
+        accessibilityTraits: UIAccessibilityTraits? = nil,
         verticalPadding: VerticalPadding? = nil,
         horizontal: HorizontalPadding? = nil,
     ) {
@@ -30,6 +34,8 @@ public struct GDSListViewModel: ContentViewModel {
         self.titleConfig = titleConfig
         self.items = items
         self.style = style
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.accessibilityTraits = accessibilityTraits
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontal
     }

--- a/Sources/Components/GDSProgressIndicator/GDSProgressIndicator.swift
+++ b/Sources/Components/GDSProgressIndicator/GDSProgressIndicator.swift
@@ -31,7 +31,10 @@ public final class GDSProgressIndicator: UIView, ContentView {
         
         stack.isAccessibilityElement = true
         stack.accessibilityLabel = viewModel.title.title.value
-        stack.accessibilityIdentifier = "progress-indicator-stack-view"
+        if let accessibilityTraits = viewModel.accessibilityTraits {
+            stack.accessibilityTraits = accessibilityTraits
+        }
+        stack.accessibilityIdentifier = viewModel.accessibilityIdentifier ?? "progress-indicator-stack-view"
         
         return stack
     }()

--- a/Sources/Components/GDSProgressIndicator/GDSProgressIndicatorViewModel.swift
+++ b/Sources/Components/GDSProgressIndicator/GDSProgressIndicatorViewModel.swift
@@ -15,6 +15,8 @@ public struct GDSProgressIndicatorViewModel: ContentViewModel {
     let titleAfter10Seconds: GDSTextViewModel
     let progressIndicatorColor: UIColor?
     
+    public let accessibilityIdentifier: String?
+    public let accessibilityTraits: UIAccessibilityTraits?
     public let verticalPadding: VerticalPadding?
     public let horizontalPadding: HorizontalPadding?
     
@@ -23,6 +25,8 @@ public struct GDSProgressIndicatorViewModel: ContentViewModel {
         titleAfter5Seconds: GDSTextViewModel = .init(title: GDSLocalisedString(stringKey: "fiveSecondLoadingText", bundle: .designSystem)),
         titleAfter10Seconds: GDSTextViewModel = .init(title: GDSLocalisedString(stringKey: "tenSecondLoadingText", bundle: .designSystem)),
         progressIndicatorColor: UIColor? = nil,
+        accessibilityIdentifier: String? = nil,
+        accessibilityTraits: UIAccessibilityTraits? = nil,
         verticalPadding: VerticalPadding? = .vertical(DesignSystem.Spacing.default),
         horizontalPadding: HorizontalPadding? = .horizontal(DesignSystem.Spacing.default)
     ) {
@@ -30,6 +34,8 @@ public struct GDSProgressIndicatorViewModel: ContentViewModel {
         self.titleAfter5Seconds = titleAfter5Seconds
         self.titleAfter10Seconds = titleAfter10Seconds
         self.progressIndicatorColor = progressIndicatorColor
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.accessibilityTraits = accessibilityTraits
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
     }

--- a/Sources/Components/GDSRow/GDSMultiRow/GDSMultiRow.swift
+++ b/Sources/Components/GDSRow/GDSMultiRow/GDSMultiRow.swift
@@ -26,6 +26,10 @@ public final class GDSMultiRow: UIView, ContentView {
     func setupView() {
         backgroundColor = viewModel.backgroundColor
         layer.cornerRadius = viewModel.cornerRadius
+        if let accessibilityTraits = viewModel.accessibilityTraits {
+            self.accessibilityTraits = accessibilityTraits
+        }
+        self.accessibilityIdentifier = viewModel.accessibilityIdentifier
         addSubview(verticalStack)
         verticalStack.bindToSuperviewEdges()
     }

--- a/Sources/Components/GDSRow/GDSMultiRow/GDSMultiRowViewModel.swift
+++ b/Sources/Components/GDSRow/GDSMultiRow/GDSMultiRowViewModel.swift
@@ -6,6 +6,8 @@ public struct GDSMultiRowViewModel: ContentViewModel {
     var backgroundColor: UIColor
     var cornerRadius: CGFloat
     
+    public var accessibilityIdentifier: String?
+    public var accessibilityTraits: UIAccessibilityTraits?
     public var verticalPadding: VerticalPadding?
     public var horizontalPadding: HorizontalPadding?
     
@@ -13,12 +15,16 @@ public struct GDSMultiRowViewModel: ContentViewModel {
         rows: [GDSRowViewModel] = [],
         backgroundColor: UIColor = .secondarySystemBackground,
         cornerRadius: CGFloat = DesignSystem.CornerRadius.row,
+        accessibilityIdentifier: String? = nil,
+        accessibilityTraits: UIAccessibilityTraits? = nil,
         verticalPadding: VerticalPadding? = nil,
         horizontalPadding: HorizontalPadding? = nil
     ) {
         self.rows = rows
         self.backgroundColor = backgroundColor
         self.cornerRadius = cornerRadius
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.accessibilityTraits = accessibilityTraits
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
     }

--- a/Sources/Components/GDSRow/GDSRow.swift
+++ b/Sources/Components/GDSRow/GDSRow.swift
@@ -252,7 +252,10 @@ public final class GDSRow: UIControl, ContentView {
     
     private func setupAccessibility() {
         isAccessibilityElement = true
-        accessibilityTraits = viewModel.accessibilityTraits
+        if let accessibilityTraits = viewModel.accessibilityTraits {
+            self.accessibilityTraits = accessibilityTraits
+        }
+        self.accessibilityIdentifier = viewModel.accessibilityIdentifier
         accessibilityHint = viewModel.iconStyle?.accessibilityHint
         
         let labels = [

--- a/Sources/Components/GDSRow/GDSRowViewModel.swift
+++ b/Sources/Components/GDSRow/GDSRowViewModel.swift
@@ -15,7 +15,8 @@ public struct GDSRowViewModel: ContentViewModel, Identifiable {
     var image: UIImage?
     var imageAltText: String?
     var iconStyle: IconStyle?
-    var accessibilityTraits: UIAccessibilityTraits
+    public var accessibilityTraits: UIAccessibilityTraits?
+    public var accessibilityIdentifier: String?
     var type: RowType
     var action: DesignSystem.Action?
     
@@ -34,7 +35,8 @@ public struct GDSRowViewModel: ContentViewModel, Identifiable {
         image: UIImage? = nil,
         imageAltText: String? = nil,
         iconStyle: IconStyle? = nil,
-        accessibilityTraits: UIAccessibilityTraits = [],
+        accessibilityTraits: UIAccessibilityTraits? = nil,
+        accessibilityIdentifier: String? = nil,
         type: RowType = .tall,
         action: DesignSystem.Action? = nil
     ) {
@@ -54,6 +56,7 @@ public struct GDSRowViewModel: ContentViewModel, Identifiable {
         self.imageAltText = imageAltText
         self.iconStyle = iconStyle
         self.accessibilityTraits = accessibilityTraits
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.type = type
         self.action = action
     }

--- a/Sources/Components/GDSStatusOverlay/GDSStatusOverlay.swift
+++ b/Sources/Components/GDSStatusOverlay/GDSStatusOverlay.swift
@@ -42,8 +42,8 @@ public final class GDSStatusOverlay: UIView, ContentView {
         stack.isAccessibilityElement = true
         stack.shouldGroupAccessibilityChildren = true
         stack.accessibilityLabel = viewModel.accessibilityLabel
-        stack.accessibilityTraits = [.none]
-        stack.accessibilityIdentifier = "status-overlay-stack-view"
+        stack.accessibilityTraits = viewModel.accessibilityTraits ?? [.none]
+        stack.accessibilityIdentifier = viewModel.accessibilityIdentifier ?? "status-overlay-stack-view"
         
         return stack
     }()

--- a/Sources/Components/GDSStatusOverlay/GDSStatusOverlayViewModel.swift
+++ b/Sources/Components/GDSStatusOverlay/GDSStatusOverlayViewModel.swift
@@ -12,6 +12,8 @@ public struct GDSStatusOverlayViewModel: ContentViewModel {
     let statusOverlayText: GDSTextViewModel
     let iconStyle: IconStyle?
     
+    public var accessibilityIdentifier: String?
+    public var accessibilityTraits: UIAccessibilityTraits?
     public var verticalPadding: VerticalPadding? = .vertical(DesignSystem.Spacing.default)
     public var horizontalPadding: HorizontalPadding? = .horizontal(DesignSystem.Spacing.default)
     
@@ -21,9 +23,13 @@ public struct GDSStatusOverlayViewModel: ContentViewModel {
     
     public init(
         iconStyle: IconStyle? = .statusOverlay,
-        statusText: GDSTextViewModel
+        statusText: GDSTextViewModel,
+        accessibilityIdentifier: String? = nil,
+        accessibilityTraits: UIAccessibilityTraits? = nil
     ) {
         self.iconStyle = iconStyle
         self.statusOverlayText = statusText
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.accessibilityTraits = accessibilityTraits
     }
 }

--- a/Sources/Components/GDSText/GDSTextViewModel.swift
+++ b/Sources/Components/GDSText/GDSTextViewModel.swift
@@ -7,9 +7,9 @@ public struct GDSTextViewModel: ContentViewModel {
     let titleFont: UIFont
     let textColor: UIColor
     let alignment: NSTextAlignment
-    let accessibilityTraits: UIAccessibilityTraits?
-    let accessibilityIdentifier: String?
 
+    public let accessibilityTraits: UIAccessibilityTraits?
+    public let accessibilityIdentifier: String?
     public let verticalPadding: VerticalPadding?
     public let horizontalPadding: HorizontalPadding?
     

--- a/Sources/Components/GDSWarningText/GDSWarningText.swift
+++ b/Sources/Components/GDSWarningText/GDSWarningText.swift
@@ -35,8 +35,8 @@ public final class GDSWarningText: UIView, ContentView {
         stack.isAccessibilityElement = true
         stack.shouldGroupAccessibilityChildren = true
         stack.accessibilityLabel = viewModel.accessibilityLabel
-        stack.accessibilityTraits = viewModel.warningText.accessibilityTraits ?? [.none]
-        stack.accessibilityIdentifier = "warning-text-stack-view"
+        stack.accessibilityTraits = viewModel.accessibilityTraits ?? viewModel.warningText.accessibilityTraits ?? [.none]
+        stack.accessibilityIdentifier = viewModel.accessibilityIdentifier ?? "warning-text-stack-view"
         
         return stack
     }()

--- a/Sources/Components/GDSWarningText/GDSWarningTextViewModel.swift
+++ b/Sources/Components/GDSWarningText/GDSWarningTextViewModel.swift
@@ -13,6 +13,8 @@ public struct GDSWarningTextViewModel: ContentViewModel {
     let warningText: GDSTextViewModel
     let iconSpacing: CGFloat
     
+    public var accessibilityIdentifier: String?
+    public var accessibilityTraits: UIAccessibilityTraits?
     public var verticalPadding: VerticalPadding?
     public var horizontalPadding: HorizontalPadding?
     
@@ -29,11 +31,15 @@ public struct GDSWarningTextViewModel: ContentViewModel {
         iconStyle: IconStyle? = .warning,
         warningText: GDSTextViewModel,
         iconSpacing: CGFloat = DesignSystem.Spacing.GDSWarningText.default,
+        accessibilityIdentifier: String? = nil,
+        accessibilityTraits: UIAccessibilityTraits? = nil,
         verticalPadding: VerticalPadding? = .vertical(DesignSystem.Spacing.default),
         horizontalPadding: HorizontalPadding? = .horizontal(DesignSystem.Spacing.default)
     ) {
         self.iconStyle = iconStyle
         self.warningText = warningText
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.accessibilityTraits = accessibilityTraits
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
         self.iconSpacing = iconSpacing

--- a/Tests/Components/GDSCard/GDSCardTests.swift
+++ b/Tests/Components/GDSCard/GDSCardTests.swift
@@ -116,4 +116,16 @@ struct GDSCardViewTests {
         let titleStackView = try #require(cardStackView.arrangedSubviews[1] as? UIStackView)
         #expect(titleStackView.arrangedSubviews.count == 1)
     }
+    
+    @Test("Card has custom accessibility identifier and traits")
+    func customAccessibility() throws {
+        let viewModel = GDSCardViewModel(
+            accessibilityIdentifier: "custom-card",
+            accessibilityTraits: .header,
+            contentItems: { }
+        )
+        let sut = viewModel.createUIView()
+        #expect(sut.accessibilityIdentifier == "custom-card")
+        #expect(sut.accessibilityTraits == .header)
+    }
 }

--- a/Tests/Components/GDSCard/GDSCardTitleTests.swift
+++ b/Tests/Components/GDSCard/GDSCardTitleTests.swift
@@ -47,4 +47,15 @@ struct GDSCardTitleTests {
         #expect(label.textAlignment == .center)
         #expect(label.accessibilityTraits == .header)
     }
+    
+    @Test("CardTitle has custom accessibility identifier")
+    func customAccessibilityIdentifier() throws {
+        let viewModel = GDSCardTitleViewModel(
+            title: "test title",
+            accessibilityIdentifier: "custom-card-title"
+        )
+        let sut = GDSCardTitleView(viewModel: viewModel)
+        let label = try #require(sut.arrangedSubviews[1] as? UILabel)
+        #expect(label.accessibilityIdentifier == "custom-card-title")
+    }
 }

--- a/Tests/Components/GDSDivider/GDSDividerTests.swift
+++ b/Tests/Components/GDSDivider/GDSDividerTests.swift
@@ -27,4 +27,18 @@ struct GDSDividerTests {
             $0.firstAttribute == .height && $0.constant == (3 / UIScreen.main.scale) && $0.isActive
         }))
     }
+    
+    @Test("Divider has custom accessibility identifier")
+    func customAccessibilityIdentifier() {
+        let viewModel = GDSDividerViewModel(accessibilityIdentifier: "custom-divider")
+        let sut = GDSDividerView(viewModel: viewModel)
+        #expect(sut.accessibilityIdentifier == "custom-divider")
+    }
+    
+    @Test("Divider has custom accessibility traits")
+    func customAccessibilityTraits() {
+        let viewModel = GDSDividerViewModel(accessibilityTraits: .staticText)
+        let sut = GDSDividerView(viewModel: viewModel)
+        #expect(sut.accessibilityTraits == .staticText)
+    }
 }

--- a/Tests/Components/GDSErrorIcon/GDSErrorIconTitleTests.swift
+++ b/Tests/Components/GDSErrorIcon/GDSErrorIconTitleTests.swift
@@ -140,4 +140,28 @@ struct GDSErrorIconTitleTests {
         #expect(stackView?.accessibilityTraits.contains(.header) == false)
     }
     
+    @Test("ErrorIconTitle has custom accessibility identifier")
+    func customAccessibilityIdentifier() {
+        let viewModel = GDSErrorIconTitleViewModel(
+            icon: .error,
+            errorTitle: GDSTextViewModel(title: "Error"),
+            accessibilityIdentifier: "custom-error-icon"
+        )
+        let view = GDSErrorIconTitle(viewModel: viewModel)
+        let stackView = view.subviews.first as? UIStackView
+        #expect(stackView?.accessibilityIdentifier == "custom-error-icon")
+    }
+    
+    @Test("ErrorIconTitle viewModel accessibilityTraits overrides errorTitle traits")
+    func viewModelTraitsOverrideErrorTitleTraits() {
+        let viewModel = GDSErrorIconTitleViewModel(
+            icon: .error,
+            errorTitle: GDSTextViewModel(title: "Error", accessibilityTraits: .header),
+            accessibilityTraits: .staticText
+        )
+        let view = GDSErrorIconTitle(viewModel: viewModel)
+        let stackView = view.subviews.first as? UIStackView
+        #expect(stackView?.accessibilityTraits == .staticText)
+    }
+    
 }

--- a/Tests/Components/GDSImage/GDSImageTests.swift
+++ b/Tests/Components/GDSImage/GDSImageTests.swift
@@ -66,4 +66,26 @@ struct GDSImageTests {
         #expect(heightConstraint?.relation == .equal)
         #expect(heightConstraint?.isActive ?? false)
     }
+    
+    @Test("Image has custom accessibility identifier")
+    func customAccessibilityIdentifier() {
+        let viewModel = GDSImageViewModel(
+            image: UIImage(),
+            contentMode: .scaleAspectFit,
+            accessibilityIdentifier: "custom-image"
+        )
+        let sut = GDSImageView(viewModel: viewModel)
+        #expect(sut.accessibilityIdentifier == "custom-image")
+    }
+    
+    @Test("Image has custom accessibility traits")
+    func customAccessibilityTraits() {
+        let viewModel = GDSImageViewModel(
+            image: UIImage(),
+            contentMode: .scaleAspectFit,
+            accessibilityTraits: .image
+        )
+        let sut = GDSImageView(viewModel: viewModel)
+        #expect(sut.accessibilityTraits == .image)
+    }
 }

--- a/Tests/Components/GDSList/GDSListTests.swift
+++ b/Tests/Components/GDSList/GDSListTests.swift
@@ -202,4 +202,17 @@ struct GDSListTests {
         
         sut.assertSnapshot(bindToEdges: .horizontal)
     }
+    
+    @Test("List has custom accessibility identifier and traits")
+    func customAccessibility() throws {
+        let viewModel = GDSListViewModel(
+            items: [GDSLocalisedString(stringKey: "item")],
+            style: .bulleted,
+            accessibilityIdentifier: "custom-list",
+            accessibilityTraits: .header
+        )
+        let sut = GDSList(viewModel: viewModel)
+        #expect(sut.accessibilityIdentifier == "custom-list")
+        #expect(sut.accessibilityTraits == .header)
+    }
 }

--- a/Tests/Components/GDSProgressIndicator/GDSProgressIndicatorTests.swift
+++ b/Tests/Components/GDSProgressIndicator/GDSProgressIndicatorTests.swift
@@ -53,6 +53,22 @@ struct GDSProgressIndicatorTests {
         #expect(stackView?.accessibilityIdentifier == "progress-indicator-stack-view")
     }
     
+    @Test("ProgressIndicator has custom accessibility identifier")
+    func customAccessibilityIdentifier() {
+        let vm = GDSProgressIndicatorViewModel(accessibilityIdentifier: "custom-progress")
+        let view = GDSProgressIndicator(viewModel: vm)
+        let stackView = view.subviews.first as? UIStackView
+        #expect(stackView?.accessibilityIdentifier == "custom-progress")
+    }
+    
+    @Test("ProgressIndicator has custom accessibility traits")
+    func customAccessibilityTraits() {
+        let vm = GDSProgressIndicatorViewModel(accessibilityTraits: .updatesFrequently)
+        let view = GDSProgressIndicator(viewModel: vm)
+        let stackView = view.subviews.first as? UIStackView
+        #expect(stackView?.accessibilityTraits == .updatesFrequently)
+    }
+    
     @Test("Test configuration used to change the title after 5 seconds")
     func titleViewAfterFiveSeconds() async throws {
         let progressIndicator = GDSProgressIndicator(viewModel: viewModel)

--- a/Tests/Components/GDSRow/GDSMultiRowTests.swift
+++ b/Tests/Components/GDSRow/GDSMultiRowTests.swift
@@ -64,4 +64,16 @@ struct GDSMultiRowTests {
         let drivingLicenseRow = try #require(stack.subviews[2] as? GDSRow)
         #expect(drivingLicenseRow.subviews.count == 3)
     }
+    
+    @Test("MultiRow has custom accessibility identifier and traits")
+    func customAccessibility() throws {
+        let viewModel = GDSMultiRowViewModel(
+            rows: [GDSRowViewModel(titleConfig: StyledText(text: "Test"))],
+            accessibilityIdentifier: "custom-multi-row",
+            accessibilityTraits: .header
+        )
+        let sut = GDSMultiRow(viewModel: viewModel)
+        #expect(sut.accessibilityIdentifier == "custom-multi-row")
+        #expect(sut.accessibilityTraits == .header)
+    }
 }

--- a/Tests/Components/GDSRow/GDSRowTests.swift
+++ b/Tests/Components/GDSRow/GDSRowTests.swift
@@ -164,4 +164,24 @@ struct GDSRowTests {
         try await Task.sleep(seconds: 0.1)
         #expect(didTapRow)
     }
+    
+    @Test("Row has custom accessibility identifier")
+    func customAccessibilityIdentifier() throws {
+        let viewModel = GDSRowViewModel(
+            titleConfig: StyledText(text: "Test"),
+            accessibilityIdentifier: "custom-row"
+        )
+        let sut = viewModel.createUIView()
+        #expect(sut.accessibilityIdentifier == "custom-row")
+    }
+    
+    @Test("Row has custom accessibility traits")
+    func customAccessibilityTraits() throws {
+        let viewModel = GDSRowViewModel(
+            titleConfig: StyledText(text: "Test"),
+            accessibilityTraits: .header
+        )
+        let sut = viewModel.createUIView()
+        #expect(sut.accessibilityTraits == .header)
+    }
 }

--- a/Tests/Components/GDSStatusOverlay/GDSStatusOverlayTests.swift
+++ b/Tests/Components/GDSStatusOverlay/GDSStatusOverlayTests.swift
@@ -69,4 +69,26 @@ struct GDSStatusOverlayTests {
             #expect(presentation?.accessibilityElementsHidden == false)
         }
     }
+    
+    @Test("StatusOverlay has custom accessibility identifier")
+    func customAccessibilityIdentifier() {
+        let vm = GDSStatusOverlayViewModel(
+            statusText: GDSTextViewModel(title: "Done"),
+            accessibilityIdentifier: "custom-overlay"
+        )
+        let view = GDSStatusOverlay(viewModel: vm)
+        let stackView = view.subviews.first as? UIStackView
+        #expect(stackView?.accessibilityIdentifier == "custom-overlay")
+    }
+    
+    @Test("StatusOverlay has custom accessibility traits")
+    func customAccessibilityTraits() {
+        let vm = GDSStatusOverlayViewModel(
+            statusText: GDSTextViewModel(title: "Done"),
+            accessibilityTraits: .updatesFrequently
+        )
+        let view = GDSStatusOverlay(viewModel: vm)
+        let stackView = view.subviews.first as? UIStackView
+        #expect(stackView?.accessibilityTraits == .updatesFrequently)
+    }
 }

--- a/Tests/Components/GDSWarningText/GDSWarningTextTests.swift
+++ b/Tests/Components/GDSWarningText/GDSWarningTextTests.swift
@@ -113,4 +113,26 @@ struct GDSWarningTextTests {
         
         #expect(viewModel.accessibilityLabel == "Warning: Please try again")
     }
+    
+    @Test("WarningText has custom accessibility identifier")
+    func customAccessibilityIdentifier() {
+        let viewModel = GDSWarningTextViewModel(
+            warningText: GDSTextViewModel(title: "Warning", titleFont: DesignSystem.Font.Base.calloutSemiBold),
+            accessibilityIdentifier: "custom-warning"
+        )
+        let view = GDSWarningText(viewModel: viewModel)
+        let stackView = view.subviews.first as? UIStackView
+        #expect(stackView?.accessibilityIdentifier == "custom-warning")
+    }
+    
+    @Test("WarningText has custom accessibility traits")
+    func customAccessibilityTraits() {
+        let viewModel = GDSWarningTextViewModel(
+            warningText: GDSTextViewModel(title: "Warning", titleFont: DesignSystem.Font.Base.calloutSemiBold),
+            accessibilityTraits: .header
+        )
+        let view = GDSWarningText(viewModel: viewModel)
+        let stackView = view.subviews.first as? UIStackView
+        #expect(stackView?.accessibilityTraits == .header)
+    }
 }


### PR DESCRIPTION
# DCMAW-20958 Add accessibility identifier and traits to `ContentViewModel` 

These changes are non-breaking but add the flexibility to the protocol so that if required they are used and if not, they can be ignored.

This work relates to un-actioned comment on previous PR: https://github.com/govuk-one-login/mobile-ios-ui/pull/105#discussion_r3414281332

# Checklist

## Before raising your pull request:
- [x] Ran and tested the app locally ensuring it builds
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
