### PR TITLE
feat:  DCMAW-15957:  Make the corner radius of GDSCardView configurable

### DIFF
--- a/Sources/Components/GDSCard/GDSCard.swift
+++ b/Sources/Components/GDSCard/GDSCard.swift
@@ -10,7 +10,7 @@ public final class GDSCard: UIView, ContentView {
             distribution: .fill
         )
         stackView.backgroundColor = viewModel.backgroundColour
-        stackView.layer.cornerRadius = DesignSystem.CornerRadius.card
+        stackView.layer.cornerRadius = viewModel.cornerRadius
         stackView.layer.masksToBounds = true
         if let borderStyle = viewModel.borderStyle {
             stackView.layer.borderColor = borderStyle.color.cgColor

--- a/Sources/Components/GDSCard/GDSCardViewModel.swift
+++ b/Sources/Components/GDSCard/GDSCardViewModel.swift
@@ -5,6 +5,7 @@ public struct GDSCardViewModel: ContentViewModel {
     
     let backgroundColour: UIColor
     let borderStyle: BorderStyle?
+    let cornerRadius: CGFloat
     let showShadow: Bool
     let dismissAction: DesignSystem.Action?
     
@@ -18,6 +19,7 @@ public struct GDSCardViewModel: ContentViewModel {
     public init(
         backgroundColour: UIColor = DesignSystem.Color.Backgrounds.card,
         borderStyle: BorderStyle? = nil,
+        cornerRadius: CGFloat = DesignSystem.CornerRadius.card,
         showShadow: Bool = false,
         dismissAction: DesignSystem.Action? = nil,
         accessibilityIdentifier: String? = nil,
@@ -28,6 +30,7 @@ public struct GDSCardViewModel: ContentViewModel {
     ) {
         self.backgroundColour = backgroundColour
         self.borderStyle = borderStyle
+        self.cornerRadius = cornerRadius
         self.showShadow = showShadow
         self.dismissAction = dismissAction
         self.accessibilityIdentifier = accessibilityIdentifier

--- a/Tests/Components/GDSCard/GDSCardTests.swift
+++ b/Tests/Components/GDSCard/GDSCardTests.swift
@@ -18,7 +18,25 @@ struct GDSCardViewTests {
         #expect(cardStackView.translatesAutoresizingMaskIntoConstraints == false)
         #expect(cardStackView.backgroundColor == DesignSystem.Color.Backgrounds.card)
     }
-    
+
+    @Test("Check corner radius is configurable for the outer stack view")
+    func encasingStackCornerRadius() throws {
+        let viewModel = GDSCardViewModel(
+            cornerRadius: 0.0,
+            contentItems: { }
+        )
+        let sut = viewModel.createUIView()
+        let cardStackView = try #require(sut.subviews.first as? UIStackView)
+
+        #expect(cardStackView.spacing == .zero)
+        #expect(cardStackView.alignment == .fill)
+        #expect(cardStackView.distribution == .fill)
+        #expect(cardStackView.layer.cornerRadius == 0)
+        #expect(cardStackView.layer.masksToBounds == true)
+        #expect(cardStackView.translatesAutoresizingMaskIntoConstraints == false)
+        #expect(cardStackView.backgroundColor == DesignSystem.Color.Backgrounds.card)
+    }
+
     @Test("Check shadow is show for the outer stack view")
     func encasingStackShadowAndBorder() throws {
         let viewModel = GDSCardViewModel(


### PR DESCRIPTION
# Make the corner radius of GDSCardView configurable

Added the abillty to specify a corner radius on card views, keeping a default value of DesignSystem.CornerRadius.card.  This was done to support migration of Wallet screens to the Design System

https://govukverify.atlassian.net/browse/DCMAW-15957

# Checklist

## Before raising your pull request:
- [x] Ran and tested the app locally ensuring it builds
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
