### PR TITLE
fix:  DCMAW-15967 - document-info-screen-implement-design-system accessibility fix

### DIFF
--- a/Sources/Components/GDSButton/GDSButton.swift
+++ b/Sources/Components/GDSButton/GDSButton.swift
@@ -47,7 +47,10 @@ public final class GDSButton: UIButton, ContentView {
                 ]
             )
         }
-        
+
+        if let accessibilityTraits = viewModel.accessibilityTraits {
+            self.accessibilityTraits = accessibilityTraits
+        }
         self.accessibilityIdentifier = viewModel.accessibilityIdentifier
     }
     


### PR DESCRIPTION
# Have GDSButton recognize accessibilityTraits set in GDSButtonViewModel

GDSButton was not ingesting the accessibilityTraits set on GDSButtonViewModel.  This prevented have VO announce "Link" instead of "Button" in those cases where we wanted to let the user know about link behavior.

This VO movie has the fixed version announcing "link" by temporarily adding the trait in ViewController.swift.  That. change has not been committed.


# Checklist

https://github.com/user-attachments/assets/38d85f3c-cada-4e84-921a-a78b2a71e025



## Before raising your pull request:
- [x] Ran and tested the app locally ensuring it builds
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
