### PR TITLE
feat: DCMAW-21531 - add declarative navigation bar button configuration

### DIFF
--- a/Demo/DesignSystemDemo/NavigationBarButtonDemoViewController.swift
+++ b/Demo/DesignSystemDemo/NavigationBarButtonDemoViewController.swift
@@ -1,0 +1,269 @@
+import DesignSystem
+import UIKit
+
+// MARK: - Demo List Controller
+
+/// Lists each NavigationBarButton usage variation for the demo.
+final class NavigationBarButtonDemoViewController: UITableViewController {
+
+    private enum Example: Int, CaseIterable {
+        case legacy
+        case singleButton
+        case multipleButtons
+        case menuButton
+
+        var title: String {
+            switch self {
+            case .legacy: return "Legacy rightBarButtonTitle"
+            case .singleButton: return "Single Button (new API)"
+            case .multipleButtons: return "Multiple Buttons (new API)"
+            case .menuButton: return "Menu with Items"
+            }
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "NavigationBarButton"
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+    }
+
+    override func tableView(
+        _ tableView: UITableView,
+        numberOfRowsInSection section: Int
+    ) -> Int {
+        Example.allCases.count
+    }
+
+    override func tableView(
+        _ tableView: UITableView,
+        cellForRowAt indexPath: IndexPath
+    ) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        cell.textLabel?.text = Example.allCases[indexPath.row].title
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }
+
+    override func tableView(
+        _ tableView: UITableView,
+        didSelectRowAt indexPath: IndexPath
+    ) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let example = Example.allCases[indexPath.row]
+
+        let screen: GDSScreen
+        switch example {
+        case .legacy:
+            let legacyScreen = GDSScreen(viewModel: LegacyBarButtonViewModel())
+            let modalNav = UINavigationController(rootViewController: legacyScreen)
+            present(modalNav, animated: true)
+            return
+        case .singleButton:
+            screen = GDSScreen(viewModel: SingleBarButtonViewModel())
+        case .multipleButtons:
+            let viewModel = MultipleBarButtonsViewModel(closeAction: { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+            })
+            screen = GDSScreen(viewModel: viewModel)
+        case .menuButton:
+            screen = GDSScreen(viewModel: MenuBarButtonViewModel())
+        }
+
+        navigationController?.pushViewController(screen, animated: true)
+    }
+}
+
+// MARK: - 1. Legacy Usage
+// Uses the original `rightBarButtonTitle` property to create a dismiss-style button.
+
+private struct LegacyBarButtonViewModel: GDSScreenViewModel, BaseViewModel {
+    let screenStyle: GDSScreenStyle = .top
+    let body: [any ContentViewModel] = [
+        GDSTextViewModel(
+            title: "Legacy Usage",
+            titleFont: DesignSystem.Font.Base.title1Bold,
+            alignment: .center,
+            accessibilityTraits: .header
+        ),
+        GDSTextViewModel(
+            title: """
+            This screen uses the original `rightBarButtonTitle` property. \
+            It creates a bar button with .done style that dismisses the screen.
+            """,
+            titleFont: DesignSystem.Font.Base.body,
+            alignment: .left
+        )
+    ]
+    let movableFooter: [any ContentViewModel] = []
+    let footer: [any ContentViewModel] = []
+
+    // Legacy API
+    let rightBarButtonTitle: GDSLocalisedString? = "Done"
+    let backButtonTitle: GDSLocalisedString? = "Back"
+    let backButtonIsHidden: Bool = false
+    let didAppear: DesignSystem.Action? = nil
+    let didDismiss: DesignSystem.Action? = .action({ print("Legacy: didDismiss called") })
+}
+
+// MARK: - 2. Single Button (new API)
+// Uses `rightBarButtons` with a single `.button(...)` configuration.
+
+private struct SingleBarButtonViewModel: GDSScreenViewModel, BaseViewModel {
+    let screenStyle: GDSScreenStyle = .top
+    let body: [any ContentViewModel] = [
+        GDSTextViewModel(
+            title: "Single Button (New API)",
+            titleFont: DesignSystem.Font.Base.title1Bold,
+            alignment: .center,
+            accessibilityTraits: .header
+        ),
+        GDSTextViewModel(
+            title: """
+            This screen uses `rightBarButtons` with a single button. \
+            Tap the "Save" button in the navigation bar to trigger the action.
+            """,
+            titleFont: DesignSystem.Font.Base.body,
+            alignment: .left
+        )
+    ]
+    let movableFooter: [any ContentViewModel] = []
+    let footer: [any ContentViewModel] = []
+
+    // New API — single right bar button
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonTitle: GDSLocalisedString? = "Back"
+    let backButtonIsHidden: Bool = false
+    let didAppear: DesignSystem.Action? = nil
+    let didDismiss: DesignSystem.Action? = nil
+
+    var rightBarButtons: [DesignSystem.NavigationBarButton]? {
+        [
+            .button(
+                title: "Save",
+                accessibilityIdentifier: "save-button",
+                action: { print("Single button: Save tapped") }
+            )
+        ]
+    }
+}
+
+// MARK: - 3. Multiple Buttons (new API)
+// Uses `leftBarButtons` and `rightBarButtons` with multiple items.
+
+private struct MultipleBarButtonsViewModel: GDSScreenViewModel, BaseViewModel {
+    let screenStyle: GDSScreenStyle = .top
+    let body: [any ContentViewModel] = [
+        GDSTextViewModel(
+            title: "Multiple Buttons (New API)",
+            titleFont: DesignSystem.Font.Base.title1Bold,
+            alignment: .center,
+            accessibilityTraits: .header
+        ),
+        GDSTextViewModel(
+            title: """
+            This screen demonstrates multiple bar buttons on both sides. \
+            Left: a close button (image). Right: "Edit" and "Share" buttons.
+            """,
+            titleFont: DesignSystem.Font.Base.body,
+            alignment: .left
+        )
+    ]
+    let movableFooter: [any ContentViewModel] = []
+    let footer: [any ContentViewModel] = []
+
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonTitle: GDSLocalisedString? = "Back"
+    let backButtonIsHidden: Bool = true
+    let didAppear: DesignSystem.Action? = nil
+    let didDismiss: DesignSystem.Action? = nil
+
+    let closeAction: @MainActor () -> Void
+
+    var leftBarButtons: [DesignSystem.NavigationBarButton]? {
+        [
+            .button(
+                image: UIImage(systemName: "xmark"),
+                accessibilityIdentifier: "close-button",
+                action: closeAction
+            )
+        ]
+    }
+
+    var rightBarButtons: [DesignSystem.NavigationBarButton]? {
+        [
+            .button(
+                title: "Edit",
+                accessibilityIdentifier: "edit-button",
+                action: { print("Multiple buttons: Edit tapped") }
+            ),
+            .button(
+                title: "Share",
+                image: UIImage(systemName: "square.and.arrow.up"),
+                accessibilityIdentifier: "share-button",
+                action: { print("Multiple buttons: Share tapped") }
+            )
+        ]
+    }
+}
+
+// MARK: - 4. Menu with Items
+// Uses `.menu(...)` to present a contextual menu with NavigationBarMenuItem helpers.
+
+private struct MenuBarButtonViewModel: GDSScreenViewModel, BaseViewModel {
+    let screenStyle: GDSScreenStyle = .top
+    let body: [any ContentViewModel] = [
+        GDSTextViewModel(
+            title: "Menu with Items",
+            titleFont: DesignSystem.Font.Base.title1Bold,
+            alignment: .center,
+            accessibilityTraits: .header
+        ),
+        GDSTextViewModel(
+            title: """
+            This screen uses a `.menu(...)` bar button. \
+            Tap the ellipsis icon to see menu items built with `NavigationBarMenuItem`.
+            """,
+            titleFont: DesignSystem.Font.Base.body,
+            alignment: .left
+        )
+    ]
+    let movableFooter: [any ContentViewModel] = []
+    let footer: [any ContentViewModel] = []
+
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonTitle: GDSLocalisedString? = "Back"
+    let backButtonIsHidden: Bool = false
+    let didAppear: DesignSystem.Action? = nil
+    let didDismiss: DesignSystem.Action? = nil
+
+    var rightBarButtons: [DesignSystem.NavigationBarButton]? {
+        [
+            .menu(
+                image: UIImage(systemName: "ellipsis.circle"),
+                accessibilityIdentifier: "menu-button",
+                menuProvider: { completion in
+                    let items: [DesignSystem.NavigationBarMenuItem] = [
+                        .init(
+                            title: "Share",
+                            image: UIImage(systemName: "square.and.arrow.up"),
+                            action: { print("Menu: Share tapped") }
+                        ),
+                        .init(
+                            title: "Copy Link",
+                            image: UIImage(systemName: "link"),
+                            action: { print("Menu: Copy Link tapped") }
+                        ),
+                        .init(
+                            title: "Delete",
+                            image: UIImage(systemName: "trash"),
+                            isDestructive: true,
+                            action: { print("Menu: Delete tapped") }
+                        )
+                    ]
+                    completion(items.map { $0.toUIAction() })
+                }
+            )
+        ]
+    }
+}

--- a/Demo/DesignSystemDemo/ViewController.swift
+++ b/Demo/DesignSystemDemo/ViewController.swift
@@ -56,6 +56,11 @@ class ViewController: UIViewController {
         navigationController?.pushViewController(screen, animated: true)
     }
 
+    func pushNavigationBarButtonDemo() {
+        let demo = NavigationBarButtonDemoViewController(style: .insetGrouped)
+        navigationController?.pushViewController(demo, animated: true)
+    }
+
     func addViewsToStack() {
         viewModel.body.forEach {
             stackview.addArrangedSubview($0.createUIView())
@@ -110,6 +115,13 @@ extension ViewController {
                 style: .secondary,
                 buttonAction: .action({ [weak self] in
                     self?.pushGDSScreen()
+                })
+            ),
+            GDSButtonViewModel(
+                title: "NavigationBarButton Examples",
+                style: .secondary,
+                buttonAction: .action({ [weak self] in
+                    self?.pushNavigationBarButtonDemo()
                 })
             ),
             GDSTextViewModel(

--- a/Demo/DesignSystemDemoTests/NavigationBarButtonDemoViewControllerTests.swift
+++ b/Demo/DesignSystemDemoTests/NavigationBarButtonDemoViewControllerTests.swift
@@ -1,5 +1,5 @@
-@testable import DesignSystemDemo
 import DesignSystem
+@testable import DesignSystemDemo
 import Testing
 import UIKit
 

--- a/Demo/DesignSystemDemoTests/NavigationBarButtonDemoViewControllerTests.swift
+++ b/Demo/DesignSystemDemoTests/NavigationBarButtonDemoViewControllerTests.swift
@@ -1,0 +1,177 @@
+@testable import DesignSystemDemo
+import DesignSystem
+import Testing
+import UIKit
+
+@MainActor
+struct NavigationBarButtonDemoViewControllerTests {
+
+    // MARK: - Table View Setup
+
+    @Test
+    func viewDidLoad_setsTitle() {
+        let sut = NavigationBarButtonDemoViewController(style: .insetGrouped)
+        sut.loadViewIfNeeded()
+
+        #expect(sut.title == "NavigationBarButton")
+    }
+
+    @Test
+    func tableView_hasFourRows() {
+        let sut = NavigationBarButtonDemoViewController(style: .insetGrouped)
+        sut.loadViewIfNeeded()
+
+        #expect(sut.tableView.numberOfRows(inSection: 0) == 4)
+    }
+
+    @Test
+    func tableView_cellTitles() {
+        let sut = NavigationBarButtonDemoViewController(style: .insetGrouped)
+        sut.loadViewIfNeeded()
+
+        let expectedTitles = [
+            "Legacy rightBarButtonTitle",
+            "Single Button (new API)",
+            "Multiple Buttons (new API)",
+            "Menu with Items"
+        ]
+
+        for (index, expected) in expectedTitles.enumerated() {
+            let cell = sut.tableView(
+                sut.tableView,
+                cellForRowAt: IndexPath(row: index, section: 0)
+            )
+            #expect(cell.textLabel?.text == expected)
+            #expect(cell.accessoryType == .disclosureIndicator)
+        }
+    }
+
+    // MARK: - Legacy Usage
+
+    @Test
+    func legacyExample_presentsScreenModally() throws {
+        let (sut, nav) = makeNavigationController()
+
+        // Modal presentation requires a window hierarchy
+        let window = UIWindow()
+        window.rootViewController = nav
+        window.makeKeyAndVisible()
+
+        sut.tableView(sut.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
+
+        let modalNav = try #require(sut.presentedViewController as? UINavigationController)
+        let presentedScreen = try #require(modalNav.viewControllers.first as? GDSScreen)
+        presentedScreen.beginAppearanceTransition(true, animated: false)
+        presentedScreen.endAppearanceTransition()
+
+        let rightButton = try #require(presentedScreen.navigationItem.rightBarButtonItem)
+        #expect(rightButton.title == "Done")
+        #expect(rightButton.style == .done)
+        #expect(rightButton.accessibilityIdentifier == "right-bar-button")
+
+        window.resignKey()
+        window.isHidden = true
+    }
+
+    // MARK: - Single Button (new API)
+
+    @Test
+    func singleButtonExample_pushesScreenWithSaveButton() throws {
+        let (sut, nav) = makeNavigationController()
+
+        sut.tableView(sut.tableView, didSelectRowAt: IndexPath(row: 1, section: 0))
+
+        let pushedScreen = try #require(nav.viewControllers.last as? GDSScreen)
+        pushedScreen.beginAppearanceTransition(true, animated: false)
+        pushedScreen.endAppearanceTransition()
+
+        let rightButton = try #require(pushedScreen.navigationItem.rightBarButtonItem)
+        #expect(rightButton.title == "Save")
+        #expect(rightButton.accessibilityIdentifier == "save-button")
+    }
+
+    // MARK: - Multiple Buttons (new API)
+
+    @Test
+    func multipleButtonsExample_pushesScreenWithLeftAndRightButtons() throws {
+        let (sut, nav) = makeNavigationController()
+
+        sut.tableView(sut.tableView, didSelectRowAt: IndexPath(row: 2, section: 0))
+
+        let pushedScreen = try #require(nav.viewControllers.last as? GDSScreen)
+        pushedScreen.beginAppearanceTransition(true, animated: false)
+        pushedScreen.endAppearanceTransition()
+
+        // Left bar button: close
+        let leftButton = try #require(pushedScreen.navigationItem.leftBarButtonItem)
+        #expect(leftButton.image != nil)
+        #expect(leftButton.accessibilityIdentifier == "close-button")
+
+        // Right bar buttons: Edit + Share
+        let rightButtons = try #require(pushedScreen.navigationItem.rightBarButtonItems)
+        #expect(rightButtons.count == 2)
+        #expect(rightButtons[0].title == "Edit")
+        #expect(rightButtons[0].accessibilityIdentifier == "edit-button")
+        #expect(rightButtons[1].accessibilityIdentifier == "share-button")
+        #expect(rightButtons[1].image != nil)
+    }
+
+    @Test
+    func multipleButtonsExample_hidesBackButton() throws {
+        let (sut, nav) = makeNavigationController()
+
+        sut.tableView(sut.tableView, didSelectRowAt: IndexPath(row: 2, section: 0))
+
+        let pushedScreen = try #require(nav.viewControllers.last as? GDSScreen)
+        pushedScreen.beginAppearanceTransition(true, animated: false)
+        pushedScreen.endAppearanceTransition()
+
+        #expect(pushedScreen.navigationItem.hidesBackButton == true)
+    }
+
+    // MARK: - Menu with Items
+
+    @Test
+    func menuExample_pushesScreenWithMenuButton() throws {
+        let (sut, nav) = makeNavigationController()
+
+        sut.tableView(sut.tableView, didSelectRowAt: IndexPath(row: 3, section: 0))
+
+        let pushedScreen = try #require(nav.viewControllers.last as? GDSScreen)
+        pushedScreen.beginAppearanceTransition(true, animated: false)
+        pushedScreen.endAppearanceTransition()
+
+        let rightButton = try #require(pushedScreen.navigationItem.rightBarButtonItem)
+        #expect(rightButton.image != nil)
+        #expect(rightButton.menu != nil)
+        #expect(rightButton.accessibilityIdentifier == "menu-button")
+    }
+
+    @Test
+    func menuExample_menuUsesDeferredElement() throws {
+        let (sut, nav) = makeNavigationController()
+
+        sut.tableView(sut.tableView, didSelectRowAt: IndexPath(row: 3, section: 0))
+
+        let pushedScreen = try #require(nav.viewControllers.last as? GDSScreen)
+        pushedScreen.beginAppearanceTransition(true, animated: false)
+        pushedScreen.endAppearanceTransition()
+
+        let rightButton = try #require(pushedScreen.navigationItem.rightBarButtonItem)
+        let menu = try #require(rightButton.menu)
+        #expect(menu.children.count == 1)
+        #expect(menu.children.first is UIDeferredMenuElement)
+    }
+
+    // MARK: - Helpers
+
+    private func makeNavigationController() -> (
+        NavigationBarButtonDemoViewController,
+        UINavigationController
+    ) {
+        let sut = NavigationBarButtonDemoViewController(style: .insetGrouped)
+        let nav = UINavigationController(rootViewController: sut)
+        sut.loadViewIfNeeded()
+        return (sut, nav)
+    }
+}

--- a/Sources/Patterns/BaseScreen.swift
+++ b/Sources/Patterns/BaseScreen.swift
@@ -41,13 +41,8 @@ open class BaseScreen: UIViewController {
             isHidden: viewModel?.backButtonIsHidden ?? false
         )
         
-        if viewModel?.rightBarButtonTitle != nil {
-            self.navigationItem.rightBarButtonItem = .init(title: viewModel?.rightBarButtonTitle?.value,
-                                                           style: .done,
-                                                           target: self,
-                                                           action: #selector(dismissScreen))
-            self.navigationItem.rightBarButtonItem?.accessibilityIdentifier = "right-bar-button"
-        }
+        configureLeftBarButtons()
+        configureRightBarButtons()
     }
     
     open override func viewIsAppearing(_ animated: Bool) {
@@ -90,6 +85,61 @@ open class BaseScreen: UIViewController {
         case .none:
             return
         }
+    }
+}
+
+// MARK: - Bar Button Configuration
+
+extension BaseScreen {
+    private func configureLeftBarButtons() {
+        guard let configs = viewModel?.leftBarButtons else { return }
+        navigationItem.leftBarButtonItems = configs.map { makeBarButtonItem(from: $0) }
+    }
+
+    private func configureRightBarButtons() {
+        // New declarative API takes precedence
+        if let configs = viewModel?.rightBarButtons {
+            navigationItem.rightBarButtonItems = configs.map { makeBarButtonItem(from: $0) }
+            return
+        }
+
+        // Legacy fallback: rightBarButtonTitle creates a dismiss button
+        if viewModel?.rightBarButtonTitle != nil {
+            navigationItem.rightBarButtonItem = .init(
+                title: viewModel?.rightBarButtonTitle?.value,
+                style: .done,
+                target: self,
+                action: #selector(dismissScreen)
+            )
+            navigationItem.rightBarButtonItem?.accessibilityIdentifier = "right-bar-button"
+        }
+    }
+
+    private func makeBarButtonItem(
+        from config: DesignSystem.NavigationBarButton
+    ) -> UIBarButtonItem {
+        let item: UIBarButtonItem
+
+        switch config.content {
+        case .button(let title, let image, let style):
+            let uiAction = UIAction(title: title ?? "") { _ in config.action?() }
+            if let image {
+                item = UIBarButtonItem(image: image, primaryAction: uiAction)
+            } else {
+                item = UIBarButtonItem(primaryAction: uiAction)
+                item.style = style
+            }
+
+        case .menu(let image, let menuProvider):
+            let deferredElement = UIDeferredMenuElement.uncached { completion in
+                menuProvider(completion)
+            }
+            let menu = UIMenu(children: [deferredElement])
+            item = UIBarButtonItem(image: image, menu: menu)
+        }
+
+        item.accessibilityIdentifier = config.accessibilityIdentifier
+        return item
     }
 }
 

--- a/Sources/Patterns/NavigationBarButton.swift
+++ b/Sources/Patterns/NavigationBarButton.swift
@@ -1,0 +1,105 @@
+import UIKit
+
+/// Configuration type for navigation bar buttons.
+/// Use this to declaratively define left or right bar buttons from a view model.
+extension DesignSystem {
+    @MainActor
+    public struct NavigationBarButton {
+        public let content: Content
+        public let action: (@MainActor () -> Void)?
+        public let accessibilityIdentifier: String?
+
+        public init(
+            content: Content,
+            action: (@MainActor () -> Void)?,
+            accessibilityIdentifier: String?
+        ) {
+            self.content = content
+            self.action = action
+            self.accessibilityIdentifier = accessibilityIdentifier
+        }
+
+        /// A simple bar button with a title or image and an action closure.
+        /// When both `title` and `image` are provided, image takes visual precedence
+        /// in the navigation bar — the title is used as the accessibility label.
+        public static func button(
+            title: String? = nil,
+            image: UIImage? = nil,
+            style: UIBarButtonItem.Style = .plain,
+            accessibilityIdentifier: String? = nil,
+            action: @escaping @MainActor () -> Void
+        ) -> NavigationBarButton {
+            NavigationBarButton(
+                content: .button(
+                    title: title,
+                    image: image,
+                    style: style
+                ),
+                action: action,
+                accessibilityIdentifier: accessibilityIdentifier
+            )
+        }
+
+        /// A bar button that presents a UIMenu (e.g. an ellipsis icon with menu items).
+        /// Uses `UIDeferredMenuElement.uncached` so `menuProvider` is called each time the menu appears,
+        /// allowing the view model to track analytics or dynamically build menu items.
+        public static func menu(
+            image: UIImage? = UIImage(systemName: "ellipsis.circle"),
+            accessibilityIdentifier: String? = nil,
+            menuProvider: @escaping @MainActor (@escaping ([UIMenuElement]) -> Void) -> Void
+        ) -> NavigationBarButton {
+            NavigationBarButton(
+                content: .menu(
+                    image: image,
+                    menuProvider: menuProvider
+                ),
+                action: nil,
+                accessibilityIdentifier: accessibilityIdentifier
+            )
+        }
+    }
+}
+
+// MARK: - Content
+
+extension DesignSystem.NavigationBarButton {
+    public enum Content {
+        case button(title: String?, image: UIImage?, style: UIBarButtonItem.Style)
+        case menu(image: UIImage?, menuProvider: @MainActor (@escaping ([UIMenuElement]) -> Void) -> Void)
+    }
+}
+
+// MARK: - Menu Item
+
+extension DesignSystem {
+    /// A declarative description of a single menu item within a `NavigationBarButton.menu`.
+    @MainActor
+    public struct NavigationBarMenuItem {
+        public let title: String
+        public let image: UIImage?
+        public let attributes: UIMenuElement.Attributes
+        public let action: @MainActor () -> Void
+
+        public init(
+            title: String,
+            image: UIImage? = nil,
+            isDestructive: Bool = false,
+            action: @escaping @MainActor () -> Void
+        ) {
+            self.title = title
+            self.image = image
+            self.attributes = isDestructive ? .destructive : []
+            self.action = action
+        }
+
+        /// Converts this item to a `UIAction` for use within a `UIMenu`.
+        public func toUIAction() -> UIAction {
+            UIAction(
+                title: title,
+                image: image,
+                attributes: attributes,
+                handler: { _ in action() }
+            )
+        }
+    }
+}

--- a/Sources/Patterns/Protocols/BaseViewModel.swift
+++ b/Sources/Patterns/Protocols/BaseViewModel.swift
@@ -8,4 +8,18 @@ public protocol BaseViewModel {
     
     var didAppear: DesignSystem.Action? { get }
     var didDismiss: DesignSystem.Action? { get }
+
+    /// Declarative configurations for the left navigation bar buttons.
+    /// Return `nil` for no left bar buttons (default).
+    var leftBarButtons: [DesignSystem.NavigationBarButton]? { get }
+
+    /// Declarative configurations for the right navigation bar buttons.
+    /// Supports both simple action buttons and menu buttons.
+    /// Return `nil` to fall back to the legacy `rightBarButtonTitle` behaviour.
+    var rightBarButtons: [DesignSystem.NavigationBarButton]? { get }
+}
+
+extension BaseViewModel {
+    public var leftBarButtons: [DesignSystem.NavigationBarButton]? { nil }
+    public var rightBarButtons: [DesignSystem.NavigationBarButton]? { nil }
 }

--- a/Tests/Patterns/NavigationBarButtonBackwardCompatTests.swift
+++ b/Tests/Patterns/NavigationBarButtonBackwardCompatTests.swift
@@ -1,0 +1,199 @@
+@testable import DesignSystem
+import Testing
+import UIKit
+
+@MainActor
+struct NavigationBarButtonBackwardCompatTests {
+
+    // MARK: - Legacy rightBarButtonTitle
+
+    @Test
+    func legacyRightBarButtonTitle_stillWorks() throws {
+        let viewModel = BarButtonTestViewModel(
+            rightBarButtonTitle: "Dismiss"
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        let rightButton = try #require(sut.navigationItem.rightBarButtonItem)
+        #expect(rightButton.title == "Dismiss")
+        #expect(rightButton.accessibilityIdentifier == "right-bar-button")
+    }
+
+    @Test
+    func legacyRightBarButtonTitle_hasDoneStyle() throws {
+        let viewModel = BarButtonTestViewModel(
+            rightBarButtonTitle: "Close"
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        let rightButton = try #require(sut.navigationItem.rightBarButtonItem)
+        #expect(rightButton.style == .done)
+    }
+
+    @Test
+    func legacyRightBarButtonTitle_triggersDismissAndDidDismiss() {
+        var didDismiss = false
+        let viewModel = BarButtonTestViewModel(
+            rightBarButtonTitle: "Done",
+            didDismiss: .action({ didDismiss = true })
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        #expect(!didDismiss)
+        _ = sut.navigationItem.rightBarButtonItem?.target?.perform(
+            sut.navigationItem.rightBarButtonItem?.action
+        )
+        #expect(didDismiss)
+    }
+
+    @Test
+    func legacyViewModel_doesNotSetLeftBarButtons() {
+        let viewModel = BarButtonTestViewModel(
+            rightBarButtonTitle: "Close"
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        #expect(sut.navigationItem.leftBarButtonItems == nil)
+    }
+
+    @Test
+    func viewModelWithoutAnyBarButtonConfig_setsNothing() {
+        let viewModel = LegacyViewModelWithNoButtons()
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        #expect(sut.navigationItem.leftBarButtonItem == nil)
+        #expect(sut.navigationItem.rightBarButtonItem == nil)
+    }
+
+    @Test
+    func noBarButtons_doesNotSetAnyButtons() {
+        let viewModel = BarButtonTestViewModel()
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        #expect(sut.navigationItem.leftBarButtonItem == nil)
+        #expect(sut.navigationItem.rightBarButtonItem == nil)
+    }
+
+    // MARK: - Empty Array vs Nil
+
+    @Test
+    func leftBarButtons_emptyArray_clearsExistingButtons() {
+        let viewModel = BarButtonTestViewModel(leftBarButtons: [])
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Pre-existing")
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        #expect(sut.navigationItem.leftBarButtonItems == [])
+        #expect(sut.navigationItem.leftBarButtonItem == nil)
+    }
+
+    @Test
+    func rightBarButtons_emptyArray_clearsExistingButtons() {
+        let viewModel = BarButtonTestViewModel(rightBarButtons: [])
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Pre-existing")
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        #expect(sut.navigationItem.rightBarButtonItems == [])
+        #expect(sut.navigationItem.rightBarButtonItem == nil)
+    }
+
+    @Test
+    func leftBarButtons_nil_doesNotTouchExistingButtons() {
+        let viewModel = BarButtonTestViewModel()
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        let existingButton = UIBarButtonItem(title: "Pre-existing")
+        sut.navigationItem.leftBarButtonItem = existingButton
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        #expect(sut.navigationItem.leftBarButtonItem === existingButton)
+    }
+
+    @Test
+    func rightBarButtons_emptyArray_preventsLegacyFallback() {
+        let viewModel = BarButtonTestViewModel(
+            rightBarButtonTitle: "Dismiss",
+            rightBarButtons: []
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        #expect(sut.navigationItem.rightBarButtonItem == nil)
+    }
+
+    // MARK: - NavigationBarMenuItem
+
+    @Test
+    func menuItem_toUIAction_hasCorrectProperties() {
+        let image = UIImage(systemName: "trash")
+        var actionCalled = false
+        let menuItem = DesignSystem.NavigationBarMenuItem(
+            title: "Delete",
+            image: image,
+            isDestructive: true,
+            action: { actionCalled = true }
+        )
+
+        let uiAction = menuItem.toUIAction()
+        #expect(uiAction.title == "Delete")
+        #expect(uiAction.image != nil)
+        #expect(uiAction.attributes == .destructive)
+
+        if #available(iOS 16.0, *) {
+            uiAction.performWithSender(nil, target: nil)
+            #expect(actionCalled)
+        }
+    }
+
+    @Test
+    func menuItem_nonDestructive_hasEmptyAttributes() {
+        let menuItem = DesignSystem.NavigationBarMenuItem(
+            title: "Share",
+            action: { }
+        )
+
+        let uiAction = menuItem.toUIAction()
+        #expect(uiAction.attributes == [])
+    }
+}
+
+// MARK: - Test Helpers
+
+/// Mimics a view model that only uses the original BaseViewModel properties
+/// (no leftBarButtons, no rightBarButtons) — proves the protocol defaults work.
+private struct LegacyViewModelWithNoButtons: BaseViewModel {
+    var rightBarButtonTitle: GDSLocalisedString?
+    var backButtonTitle: GDSLocalisedString? = "back"
+    var backButtonIsHidden: Bool = false
+    var didAppear: DesignSystem.Action? = .action({ })
+    var didDismiss: DesignSystem.Action? = .action({ })
+}

--- a/Tests/Patterns/NavigationBarButtonTests.swift
+++ b/Tests/Patterns/NavigationBarButtonTests.swift
@@ -1,0 +1,284 @@
+@testable import DesignSystem
+import Testing
+import UIKit
+
+@MainActor
+struct NavigationBarButtonTests {
+
+    // MARK: - Left Bar Button
+
+    @Test
+    func leftBarButton_withTitle_configuresNavigationItem() throws {
+        let viewModel = BarButtonTestViewModel(
+            leftBarButtons: [
+                .button(title: "Done", accessibilityIdentifier: "done-button", action: { })
+            ]
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        let leftButton = try #require(sut.navigationItem.leftBarButtonItem)
+        #expect(leftButton.title == "Done")
+        #expect(leftButton.accessibilityIdentifier == "done-button")
+    }
+
+    @Test
+    func leftBarButton_withImage_configuresNavigationItem() throws {
+        let image = UIImage(systemName: "xmark")
+        let viewModel = BarButtonTestViewModel(
+            leftBarButtons: [
+                .button(image: image, accessibilityIdentifier: "close-button", action: { })
+            ]
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        let leftButton = try #require(sut.navigationItem.leftBarButtonItem)
+        #expect(leftButton.image != nil)
+        #expect(leftButton.accessibilityIdentifier == "close-button")
+    }
+
+    @Test
+    func leftBarButtons_nil_doesNotSetNavigationItem() {
+        let viewModel = BarButtonTestViewModel()
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        #expect(sut.navigationItem.leftBarButtonItems == nil)
+    }
+
+    @Test
+    func leftBarButton_actionIsCalled() throws {
+        var actionCalled = false
+        let viewModel = BarButtonTestViewModel(
+            leftBarButtons: [
+                .button(title: "Done", action: { actionCalled = true })
+            ]
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        let leftButton = try #require(sut.navigationItem.leftBarButtonItem)
+        if #available(iOS 16.0, *) {
+            leftButton.primaryAction?.performWithSender(leftButton, target: nil)
+        } else {
+            _ = leftButton.target?.perform(leftButton.action)
+        }
+        #expect(actionCalled)
+    }
+
+    // MARK: - Right Bar Button (new API)
+
+    @Test
+    func rightBarButton_withTitle_configuresNavigationItem() throws {
+        let viewModel = BarButtonTestViewModel(
+            rightBarButtons: [
+                .button(title: "Save", accessibilityIdentifier: "save-button", action: { })
+            ]
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        let rightButton = try #require(sut.navigationItem.rightBarButtonItem)
+        #expect(rightButton.title == "Save")
+        #expect(rightButton.accessibilityIdentifier == "save-button")
+    }
+
+    @Test
+    func rightBarButton_actionIsCalled() throws {
+        var actionCalled = false
+        let viewModel = BarButtonTestViewModel(
+            rightBarButtons: [
+                .button(title: "Save", action: { actionCalled = true })
+            ]
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        let rightButton = try #require(sut.navigationItem.rightBarButtonItem)
+        if #available(iOS 16.0, *) {
+            rightButton.primaryAction?.performWithSender(rightButton, target: nil)
+        } else {
+            _ = rightButton.target?.perform(rightButton.action)
+        }
+        #expect(actionCalled)
+    }
+
+    @Test
+    func rightBarButtons_takePrecedenceOverRightBarButtonTitle() throws {
+        let viewModel = BarButtonTestViewModel(
+            rightBarButtonTitle: "Legacy Title",
+            rightBarButtons: [
+                .button(title: "New Title", accessibilityIdentifier: "new-button", action: { })
+            ]
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        let rightButton = try #require(sut.navigationItem.rightBarButtonItem)
+        #expect(rightButton.title == "New Title")
+        #expect(rightButton.accessibilityIdentifier == "new-button")
+    }
+
+    // MARK: - Right Bar Button (menu)
+
+    @Test
+    func rightBarButton_withMenu_configuresNavigationItem() throws {
+        let image = UIImage(systemName: "ellipsis.circle")
+        let viewModel = BarButtonTestViewModel(
+            rightBarButtons: [
+                .menu(
+                    image: image,
+                    accessibilityIdentifier: "menu-button",
+                    menuProvider: { completion in
+                        completion([UIAction(title: "Item 1") { _ in }])
+                    }
+                )
+            ]
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        let rightButton = try #require(sut.navigationItem.rightBarButtonItem)
+        #expect(rightButton.image != nil)
+        #expect(rightButton.menu != nil)
+        #expect(rightButton.accessibilityIdentifier == "menu-button")
+    }
+
+    @Test
+    func rightBarButton_menu_usesDeferredMenuElement() throws {
+        let viewModel = BarButtonTestViewModel(
+            rightBarButtons: [
+                .menu(
+                    accessibilityIdentifier: "menu-button",
+                    menuProvider: { completion in
+                        completion([UIAction(title: "Action") { _ in }])
+                    }
+                )
+            ]
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        let rightButton = try #require(sut.navigationItem.rightBarButtonItem)
+        let menu = try #require(rightButton.menu)
+        #expect(menu.children.count == 1)
+        #expect(menu.children.first is UIDeferredMenuElement)
+    }
+
+    @Test
+    func rightBarButton_menu_menuProviderIsInvokedWhenResolved() throws {
+        var menuProviderCalled = false
+        var providedElements: [UIMenuElement] = []
+
+        let viewModel = BarButtonTestViewModel(
+            rightBarButtons: [
+                .menu(
+                    accessibilityIdentifier: "menu-button",
+                    menuProvider: { completion in
+                        menuProviderCalled = true
+                        let items = [
+                            UIAction(title: "Item 1") { _ in },
+                            UIAction(title: "Item 2") { _ in }
+                        ]
+                        providedElements = items
+                        completion(items)
+                    }
+                )
+            ]
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        // Before menu presentation, provider should not have been called
+        #expect(!menuProviderCalled)
+
+        // Verify the menuProvider is correctly wired by invoking it
+        // through the view model's configuration directly
+        guard case .menu(_, let menuProvider) = viewModel.rightBarButtons?.first?.content else {
+            Issue.record("Expected menu content")
+            return
+        }
+
+        menuProvider { elements in
+            providedElements = elements
+        }
+
+        #expect(menuProviderCalled)
+        #expect(providedElements.count == 2)
+    }
+
+    // MARK: - Multiple Buttons
+
+    @Test
+    func multipleLeftBarButtons_configuresAllItems() throws {
+        let viewModel = BarButtonTestViewModel(
+            leftBarButtons: [
+                .button(title: "Cancel", accessibilityIdentifier: "cancel-button", action: { }),
+                .button(title: "Edit", accessibilityIdentifier: "edit-button", action: { })
+            ]
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        let items = try #require(sut.navigationItem.leftBarButtonItems)
+        #expect(items.count == 2)
+        #expect(items[0].title == "Cancel")
+        #expect(items[0].accessibilityIdentifier == "cancel-button")
+        #expect(items[1].title == "Edit")
+        #expect(items[1].accessibilityIdentifier == "edit-button")
+    }
+
+    @Test
+    func multipleRightBarButtons_configuresAllItems() throws {
+        let viewModel = BarButtonTestViewModel(
+            rightBarButtons: [
+                .button(title: "Save", accessibilityIdentifier: "save-button", action: { }),
+                .menu(accessibilityIdentifier: "menu-button", menuProvider: { $0([]) })
+            ]
+        )
+        let sut = BaseScreen(viewModel: viewModel, bundle: .module)
+
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        let items = try #require(sut.navigationItem.rightBarButtonItems)
+        #expect(items.count == 2)
+        #expect(items[0].title == "Save")
+        #expect(items[1].menu != nil)
+    }
+}
+
+// MARK: - Test Helper
+
+struct BarButtonTestViewModel: BaseViewModel {
+    var rightBarButtonTitle: GDSLocalisedString?
+    var backButtonTitle: GDSLocalisedString? = "back"
+    var backButtonIsHidden: Bool = false
+    var didAppear: DesignSystem.Action? = .action({ })
+    var didDismiss: DesignSystem.Action? = .action({ })
+    var leftBarButtons: [DesignSystem.NavigationBarButton]?
+    var rightBarButtons: [DesignSystem.NavigationBarButton]?
+}


### PR DESCRIPTION
## Summary
  
  Extends `BaseViewModel` and `BaseScreen` to support declarative navigation bar button configuration from view models, without needing to subclass `GDSScreen`.
  
  ### Changes
  
  - **`NavigationBarButton.swift`** — New `DesignSystem.NavigationBarButton` configuration type with:
    - `.button(title:image:style:accessibilityIdentifier:action:)` for simple action buttons
    - `.menu(image:accessibilityIdentifier:menuProvider:)` for buttons with `UIMenu` (uses `UIDeferredMenuElement.uncached` for analytics support)
    - `NavigationBarMenuItem` helper for building menu items declaratively
  - **`BaseViewModel`** — Added `leftBarButtons` and `rightBarButtons` optional array properties with `nil` defaults (no changes required for existing conformers)
  - **`BaseScreen`** — Reads new properties in `viewWillAppear`; falls back to existing `rightBarButtonTitle` behaviour when `rightBarButtons` is `nil`
  
  ### Backward compatibility
  
  - Existing view models that only set `rightBarButtonTitle` continue to work unchanged
  - `nil` = don't configure (preserves current default), `[]` = explicitly clear buttons
  - No changes to existing tests or public API signatures

# Checklist

## Before raising your pull request:
- [x] Ran and tested the app locally ensuring it builds
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
