### PR TITLE
fix: DCMAW-22011: Fix checkov error

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -65,11 +65,13 @@ jobs:
             -Dsonar.token=$SONAR_TOKEN \
             -Dsonar.coverageReportPaths="sonarqube-generic-coverage.xml" \
             -Dsonar.pullrequest.key=$pull_number \
-            -Dsonar.pullrequest.branch=${{github.head_ref}} \
-            -Dsonar.pullrequest.base=${{github.base_ref}}
+            -Dsonar.pullrequest.branch="${GITHUB_HEAD_REF}" \
+            -Dsonar.pullrequest.base="${GITHUB_BASE_REF}"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
 
       - name: Check SonarCloud Results
         uses: sonarsource/sonarqube-quality-gate-action@7a5fffe8e523c40e0c740b6bc2712ab503e52efa # pin@v1.2.1


### PR DESCRIPTION
# Description

The failure CKV_GHA_2 occurs because GitHub Actions context expressions (like ${{ github.head_ref }}) are directly expanded into inline bash scripts before execution.

If a user creates a pull request from a maliciously named branch (e.g., main; rm -rf /), that string will be interpolated directly into the script line, causing arbitrary command execution.

By mapping ${{ github.head_ref }} to an environment variable (PULL_HEAD_REF), the shell treats the value strictly as a data string inside standard double quotes ("$PULL_HEAD_REF"), eliminating shell code execution risks.

Passing:
<img width="467" height="228" alt="Screenshot 2026-08-12 at 09 16 24" src="https://github.com/user-attachments/assets/3643e60e-47a4-48ed-a7e9-8b038f5099ff" />

# Checklist

## Before raising your pull request:
- [ ] Ran and tested the app locally ensuring it builds
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
(VoiceOver, DynamicType and using a keyboard for navigation)

## Before merging your pull request:
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
